### PR TITLE
Hoist RoPE frequency table out of inner loops

### DIFF
--- a/Sources/CPUOps/RoPE.swift
+++ b/Sources/CPUOps/RoPE.swift
@@ -14,11 +14,16 @@ public enum RoPE {
         precondition(nHeads > 0)
         precondition(headDim > 0)
         precondition(headDim % 2 == 0)
+        let halfDim = headDim / 2
+        let freqs = (0..<halfDim).map { idx in
+            1.0 / powf(10000.0, Float(2 * idx) / Float(headDim))
+        }
 
         for t in 0..<seqLen {
             for h in 0..<nHeads {
-                for i in stride(from: 0, to: headDim, by: 2) {
-                    let freq = 1.0 / powf(10000.0, Float(i) / Float(headDim))
+                for idx in 0..<halfDim {
+                    let i = idx * 2
+                    let freq = freqs[idx]
                     let value = Float(t) * freq
                     let cosv = cosf(value)
                     let sinv = sinf(value)
@@ -51,11 +56,16 @@ public enum RoPE {
         precondition(nHeads > 0)
         precondition(headDim > 0)
         precondition(headDim % 2 == 0)
+        let halfDim = headDim / 2
+        let freqs = (0..<halfDim).map { idx in
+            1.0 / powf(10000.0, Float(2 * idx) / Float(headDim))
+        }
 
         for t in 0..<seqLen {
             for h in 0..<nHeads {
-                for i in stride(from: 0, to: headDim, by: 2) {
-                    let freq = 1.0 / powf(10000.0, Float(i) / Float(headDim))
+                for idx in 0..<halfDim {
+                    let i = idx * 2
+                    let freq = freqs[idx]
                     let value = Float(t) * freq
                     let cosv = cosf(value)
                     let sinv = sinf(value)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [x] Hoist RoPE frequency constants out of the `CPUOps` forward/backward inner loops without changing rotation math or public API.
 - [x] Promote `ebd3c38` from an internal milestone to a public-release surface without changing the measured claim.
 - [x] Rewrite the top-level README so the non-echo exact decode result is the first public benchmark story, with explicit caveats and one-command repro.
 - [x] Add a checked-in benchmark artifact for the non-echo release claim that is stable enough to link publicly.
@@ -32,3 +33,7 @@
   - lead now scopes the performance number to the reproducible non-echo local-artifact benchmark
   - repro notes now state that first-run `coremltools` bootstrap may occur
   - public copy now avoids broader "CoreML in general" wording
+- RoPE CPU hot loop pass:
+  - `Sources/CPUOps/RoPE.swift` now precomputes `freqs` once per `apply()`/`backward()` call
+  - inner loops now iterate `idx in 0..<halfDim` and derive `i = idx * 2`
+  - forward and backward rotation signs remain unchanged


### PR DESCRIPTION
Summary
- precompute the RoPE frequency table once per `apply(_:_:)` and `backward(_:_:)` call to avoid redundant power/exponent work
- iterate over a half-width index, recycle the cached frequency, and keep the rotation logic identical to the previous implementation
- document the optimization in `tasks/todo.md`

Testing
- Not run (not requested)