### PR TITLE
fix: restore GPT-2 demo bootstrap helpers for clean clones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ assert not deps, f"package graph must have zero dependencies, found: {deps}"'
       - name: Assert README claims match latest.json
         run: python3 scripts/assert_readme_claims.py
 
+      - name: Assert GPT-2 demo helper scripts are present
+        run: |
+          python3 scripts/assert_demo_helpers.py
+          python3 scripts/tests/test_gpt2_demo_helpers.py -v
+
       - name: Build (release)
         run: swift build -c release
 

--- a/.gitignore
+++ b/.gitignore
@@ -85,10 +85,15 @@ scripts/internal/**
 !scripts/export_llama_coreml.py
 !scripts/convert_weights_gpt2.py
 !scripts/convert_weights_llama.py
+!scripts/bootstrap_gpt2_demo.py
+!scripts/export_gpt2_coreml.py
+!scripts/run_gpt2_coreml_reference.py
+!scripts/assert_demo_helpers.py
 !scripts/stories_prompt_suite.txt
 !scripts/tests/
 !scripts/tests/test_stories_model_identity.py
 !scripts/tests/test_espresso_llama_weights.py
+!scripts/tests/test_gpt2_demo_helpers.py
 !scripts/README.md
 tasks/
 AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,13 @@ A clean clone must resolve and build with **no** external package dependencies (
 **Run the demo**
 
 ```bash
-./espresso          # builds, downloads GPT-2 weights, launches TUI
-./espresso doctor   # check host readiness
+./espresso doctor   # check host readiness (must report scripts OK)
+./espresso prepare  # bootstrap GPT-2 demo weights + tokenizer
+./espresso          # builds if needed, launches TUI
 ```
+
+The demo helpers `scripts/bootstrap_gpt2_demo.py`, `export_gpt2_coreml.py`, and
+`run_gpt2_coreml_reference.py` must remain tracked — CI runs `scripts/assert_demo_helpers.py`.
 
 **Hardware tests** (requires Apple Silicon ANE)
 

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -12,7 +12,9 @@ ESPRESSO_WEIGHTS_DIR=~/.espresso/models/gpt2 swift run
 ESPRESSO_WEIGHTS_DIR=~/.espresso/models/gpt2 swift run SimpleInference "The sky is"
 ```
 
-Requires GPT-2 weights. Run `./espresso install` from the Espresso repo to download them.
+Requires GPT-2 weights. From the Espresso repo run `./espresso prepare` (or a first
+`./espresso` demo launch) to bootstrap weights + tokenizer into the managed cache.
+`./espresso install` only adds a PATH shim to this checkout — it does not download models.
 
 ## BenchmarkSuite
 
@@ -24,7 +26,8 @@ swift run
 swift run BenchmarkSuite "The Neural Engine is"
 ```
 
-Requires the `espresso` script to be in your PATH (run `./espresso install`).
+Requires the `espresso` launcher on your PATH (`./espresso install` writes
+`~/.local/bin/espresso` → this checkout) and demo assets from `./espresso prepare`.
 
 ## TrainingLoop
 

--- a/Examples/SimpleInference/Sources/SimpleInference/main.swift
+++ b/Examples/SimpleInference/Sources/SimpleInference/main.swift
@@ -4,7 +4,7 @@
 ///   ESPRESSO_WEIGHTS_DIR=~/.espresso/models/gpt2 swift run SimpleInference
 ///   ESPRESSO_WEIGHTS_DIR=~/.espresso/models/gpt2 swift run SimpleInference "The sky is"
 ///
-/// Run `./espresso install` from the Espresso repo first to download GPT-2 weights.
+/// Run `./espresso prepare` from the Espresso repo first to bootstrap GPT-2 weights.
 
 import Foundation
 import RealModelInference
@@ -41,6 +41,6 @@ do {
 
 } catch {
     fputs("\nError: \(error)\n", stderr)
-    fputs("Tip: run `./espresso install` from the Espresso repo to download GPT-2 weights.\n", stderr)
+    fputs("Tip: run `./espresso prepare` from the Espresso repo to bootstrap GPT-2 weights.\n", stderr)
     exit(1)
 }

--- a/README.md
+++ b/README.md
@@ -38,9 +38,13 @@ Pick one path. Everything else is optional or research.
 ```bash
 git clone https://github.com/christopherkarani/Espresso.git
 cd Espresso
-./espresso          # builds, downloads demo weights, launches TUI
-./espresso doctor   # host readiness check
+./espresso doctor   # host readiness check (scripts, ANE, Python)
+./espresso prepare  # bootstrap GPT-2 demo weights + tokenizer (network; torch/transformers)
+./espresso          # builds if needed, launches the GPT-2 TUI demo
 ```
+
+First demo run also bootstraps assets automatically when they are missing. That step needs
+network access and a Python with `torch` + `transformers` (Espresso can create a managed venv).
 
 ### 2. Serve a model (`.esp` bundles)
 
@@ -90,7 +94,8 @@ For end-to-end text generation from prepared weights, use `RealModelInference` o
 <summary>Optional tooling (bench, install, training)</summary>
 
 ```bash
-./espresso install                            # shim → ~/.local/bin
+./espresso install                            # PATH shim → this checkout (does not download weights)
+./espresso prepare                            # download/convert GPT-2 demo assets
 ./espresso compare --no-power "Hello"         # side-by-side vs CoreML (demo weights)
 swift run espresso-bench --ane-only --inference --layers 6
 swift run espresso-train                      # experimental ANE training loop

--- a/docs/gpt2-926-tokens-per-second.html
+++ b/docs/gpt2-926-tokens-per-second.html
@@ -314,21 +314,23 @@ targets: [
     ])
 ]</code></pre>
 
-  <pre><code>import Espresso
+  <pre><code>import RealModelInference
+import ModelSupport
 
-// Load the full generation pipeline
-let model = try await ANEDirectGenerationModel.load(
-    config: ModelConfig.default,  // 768-dim, 12-layer
-    weightsPath: URL(fileURLWithPath: "path/to/weights")
+// End-to-end generation from prepared Espresso weights (GPT-2 example)
+var engine = try RealModelInferenceEngine.build(
+    config: ModelRegistry.gpt2_124m,
+    weightDir: "/path/to/gpt2_124m",
+    tokenizerDir: "/path/to/gpt2_tokenizer"
 )
 
-// Autoregressive generation
-var tokens: [Int] = tokenizer.encode("Once upon a time")
-for _ in 0..&lt;200 {
-    let next = try model.nextToken(tokens: tokens)
-    tokens.append(next)
-    print(tokenizer.decode([next]), terminator: "")
-}</code></pre>
+let result = try engine.generate(prompt: "Once upon a time", maxTokens: 64) { step in
+    print(step.text, terminator: "")
+}
+print("\n\(result.tokensPerSecond) tok/s")</code></pre>
+
+  <p>For the lower-level direct ANE kernel API, see <code>ANEKernel</code> in <code>ANERuntime</code>.
+  For a copy-paste sample package, see <code>Examples/SimpleInference</code>.</p>
 
   <h2>Caveats and Limitations</h2>
 

--- a/espresso
+++ b/espresso
@@ -37,9 +37,11 @@ Examples:
 Notes:
   - No arguments launches the managed GPT-2 TUI demo.
   - A plain prompt without a subcommand also launches the TUI demo.
-  - First run may build Swift targets and bootstrap demo assets automatically.
+  - First run may build Swift targets and bootstrap demo assets automatically
+    (requires network + Python with torch/transformers, or a prior ./espresso prepare).
   - If startup fails, run ./espresso doctor.
-  - ./espresso install writes a shim that points at this checkout.
+  - ./espresso prepare only bootstraps demo weights/tokenizer.
+  - ./espresso install writes a PATH shim to this checkout (does not download weights).
 EOF
 }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,12 +7,16 @@ Stable, product-facing helper scripts. Research-only tooling lives under
 
 | Script | Purpose |
 |--------|---------|
+| `bootstrap_gpt2_demo.py` | Download/convert default GPT-2 demo weights + tokenizer (`./espresso` / `prepare`) |
+| `export_gpt2_coreml.py` | Export GPT-2 Core ML trunk baselines used by `compare` / `bench` |
+| `run_gpt2_coreml_reference.py` | Optional Python Core ML reference runner (Swift native fallback exists) |
 | `ensure_coreml_model.sh` | Ensure a CoreML baseline model is available for compare benches |
 | `generate_coreml_model.py` | Build CoreML packages used in comparisons |
 | `reproduce_local_real_artifact_claim.sh` | Reproduce the public real-artifact claim path |
 | `run_power_benchmark.sh` | Power / energy-oriented local runs |
 | `generate-benchmark-dashboard.sh` | Regenerate `docs/benchmarks.md` from `latest.json` |
 | `assert_readme_claims.py` | CI guard: README numbers must match `latest.json` |
+| `assert_demo_helpers.py` | CI guard: GPT-2 demo helper scripts must remain tracked |
 | `convert_weights_gpt2.py` / `convert_weights_llama.py` | Weight conversion helpers |
 | `espresso_llama_weights.py` / `stories_model_identity.py` | Stories/Llama weight identity helpers |
 | `export_llama_coreml.py` | Export Llama-family CoreML baselines |

--- a/scripts/assert_demo_helpers.py
+++ b/scripts/assert_demo_helpers.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Fail if espresso-generate's required GPT-2 demo helper scripts are missing.
+
+Keeps the primary `./espresso` / doctor bootstrap path clone-ready.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REQUIRED = (
+    "bootstrap_gpt2_demo.py",
+    "export_gpt2_coreml.py",
+    "run_gpt2_coreml_reference.py",
+    "convert_weights_gpt2.py",
+)
+
+
+def main() -> int:
+    scripts_dir = Path(__file__).resolve().parent
+    missing = [name for name in REQUIRED if not (scripts_dir / name).is_file()]
+    if missing:
+        print(
+            "Missing GPT-2 demo helper scripts required by espresso-generate:\n  - "
+            + "\n  - ".join(missing),
+            file=sys.stderr,
+        )
+        return 1
+    print("ok: demo helpers present:")
+    for name in REQUIRED:
+        print(f"  - {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_gpt2_demo.py
+++ b/scripts/bootstrap_gpt2_demo.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Bootstrap default GPT-2 demo weights + tokenizer for espresso-generate.
+
+Invoked by EspressoGenerate as:
+
+    bootstrap_gpt2_demo.py \\
+        --weights-out <dir> \\
+        --tokenizer-out <dir> \\
+        --cache-dir <dir>
+
+Requires: numpy, torch, transformers
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--weights-out", required=True, help="Espresso BLOBFILE weights directory")
+    parser.add_argument("--tokenizer-out", required=True, help="Directory for vocab.json + merges.txt")
+    parser.add_argument("--cache-dir", required=True, help="Hugging Face cache directory")
+    parser.add_argument("--model", default="gpt2", help="Hugging Face GPT-2 model id or local path")
+    parser.add_argument(
+        "--metadata-name",
+        default="gpt2_124m",
+        help="Name written into metadata.json (default: gpt2_124m)",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_convert_pretrained() -> Callable[..., None]:
+    path = SCRIPT_DIR / "convert_weights_gpt2.py"
+    spec = importlib.util.spec_from_file_location("convert_weights_gpt2", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.convert_pretrained_gpt2
+
+
+def bootstrap_gpt2_demo(
+    *,
+    model_name: str,
+    weights_out: Path,
+    tokenizer_out: Path,
+    cache_dir: Path,
+    metadata_name: str = "gpt2_124m",
+    convert_pretrained_gpt2: Callable[..., None] | None = None,
+    GPT2Tokenizer: Any = None,
+) -> None:
+    if GPT2Tokenizer is None:
+        try:
+            from transformers import GPT2Tokenizer as HFGPT2Tokenizer
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "transformers is required to bootstrap the GPT-2 demo. "
+                "Install torch + transformers, or set ESPRESSO_TOOLS_PYTHON to a Python that has them."
+            ) from exc
+        GPT2Tokenizer = HFGPT2Tokenizer
+
+    if convert_pretrained_gpt2 is None:
+        convert_pretrained_gpt2 = _load_convert_pretrained()
+
+    weights_out = Path(weights_out).expanduser().resolve()
+    tokenizer_out = Path(tokenizer_out).expanduser().resolve()
+    cache_dir = Path(cache_dir).expanduser().resolve()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Converting {model_name} weights → {weights_out}", flush=True)
+    convert_pretrained_gpt2(
+        model_name,
+        weights_out,
+        cache_dir=str(cache_dir),
+        metadata_name=metadata_name,
+    )
+
+    print(f"Saving GPT-2 tokenizer → {tokenizer_out}", flush=True)
+    tokenizer_out.mkdir(parents=True, exist_ok=True)
+    tokenizer = GPT2Tokenizer.from_pretrained(model_name, cache_dir=str(cache_dir))
+    tokenizer.save_pretrained(str(tokenizer_out))
+
+    vocab = tokenizer_out / "vocab.json"
+    merges = tokenizer_out / "merges.txt"
+    if not vocab.is_file() or not merges.is_file():
+        raise RuntimeError(
+            f"Tokenizer save did not produce vocab.json + merges.txt under {tokenizer_out}"
+        )
+
+    print("GPT-2 demo artifacts ready.", flush=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    bootstrap_gpt2_demo(
+        model_name=args.model,
+        weights_out=Path(args.weights_out),
+        tokenizer_out=Path(args.tokenizer_out),
+        cache_dir=Path(args.cache_dir),
+        metadata_name=args.metadata_name,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_gpt2_coreml.py
+++ b/scripts/export_gpt2_coreml.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Export a GPT-2 Core ML trunk for Espresso compare baselines.
+
+Invoked by EspressoGenerate as:
+
+    export_gpt2_coreml.py \\
+        --weights <espresso-gpt2-dir> \\
+        --output <gpt2_seqN.mlpackage> \\
+        --seq-len N
+
+The package accepts `input_ids` with shape `[1, seq_len]` (int32) and returns
+`hidden_states` with shape `[1, seq_len, hidden]` (float16) — hidden states
+*before* the final LayerNorm / LM head. Espresso's native Core ML runner applies
+final norm + classifier from the Espresso weight blobs.
+
+Requires: numpy, torch, transformers, coremltools (macOS recommended)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--weights",
+        required=True,
+        help="Espresso GPT-2 weights directory containing metadata.json",
+    )
+    parser.add_argument("--output", required=True, help="Output .mlpackage path")
+    parser.add_argument("--seq-len", required=True, type=int, help="Fixed sequence length")
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Optional Hugging Face model id/path (default: inferred from metadata name)",
+    )
+    parser.add_argument(
+        "--minimum-target",
+        default="macOS15",
+        choices=["macOS15"],
+        help="Minimum deployment target for the converted model",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help="Optional Hugging Face cache directory",
+    )
+    return parser.parse_args(argv)
+
+
+def infer_hf_model_id(metadata_name: str) -> str:
+    normalized = metadata_name.lower()
+    if normalized in {"gpt2_124m", "gpt2", "gpt2-small"}:
+        return "gpt2"
+    if "gpt2-medium" in normalized or normalized.endswith("_355m"):
+        return "gpt2-medium"
+    if "gpt2-large" in normalized or normalized.endswith("_774m"):
+        return "gpt2-large"
+    if "gpt2-xl" in normalized or normalized.endswith("_1558m"):
+        return "gpt2-xl"
+    return "gpt2"
+
+
+def _build_trunk_class() -> Any:
+    import torch
+    from torch import nn
+
+    class GPT2TrunkBeforeNorm(nn.Module):
+        """GPT-2 transformer stack without final LayerNorm / LM head."""
+
+        def __init__(self, hf_model: nn.Module, seq_len: int):
+            super().__init__()
+            transformer = hf_model.transformer
+            self.wte = transformer.wte
+            self.wpe = transformer.wpe
+            self.drop = transformer.drop
+            self.h = transformer.h
+            self.seq_len = seq_len
+            position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
+            self.register_buffer("position_ids", position_ids, persistent=False)
+
+        def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+            input_ids = input_ids.long()
+            hidden_states = self.wte(input_ids) + self.wpe(self.position_ids.to(input_ids.device))
+            hidden_states = self.drop(hidden_states)
+            for block in self.h:
+                hidden_states = block(hidden_states)[0]
+            return hidden_states
+
+    return GPT2TrunkBeforeNorm
+
+
+def minimum_target(name: str):
+    import coremltools as ct
+
+    if name != "macOS15":
+        raise ValueError(f"Unsupported minimum target: {name}")
+    return ct.target.macOS15
+
+
+def export_gpt2_coreml(
+    *,
+    weights_dir: pathlib.Path,
+    output_path: pathlib.Path,
+    seq_len: int,
+    model_id: str | None = None,
+    cache_dir: str | None = None,
+    deployment_target: str = "macOS15",
+) -> pathlib.Path:
+    if seq_len <= 0:
+        raise ValueError("--seq-len must be > 0")
+
+    import coremltools as ct
+    import numpy as np
+    import torch
+    from transformers import GPT2LMHeadModel
+
+    GPT2TrunkBeforeNorm = _build_trunk_class()
+
+    weights_dir = pathlib.Path(weights_dir).expanduser().resolve()
+    metadata_path = weights_dir / "metadata.json"
+    if not metadata_path.is_file():
+        raise FileNotFoundError(f"Missing metadata.json in {weights_dir}")
+
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    hf_model_id = model_id or infer_hf_model_id(str(metadata.get("name", "gpt2_124m")))
+
+    print(f"Loading {hf_model_id} for Core ML export (seq_len={seq_len})", flush=True)
+    hf_model = GPT2LMHeadModel.from_pretrained(
+        hf_model_id,
+        torch_dtype=torch.float16,
+        cache_dir=cache_dir,
+    )
+    hf_model.eval()
+
+    trunk = GPT2TrunkBeforeNorm(hf_model, seq_len)
+    trunk.eval()
+    example = torch.zeros((1, seq_len), dtype=torch.int32)
+
+    with torch.no_grad():
+        traced = torch.jit.trace(trunk, example, strict=False)
+
+    mlmodel = ct.convert(
+        traced,
+        inputs=[ct.TensorType(name="input_ids", shape=example.shape, dtype=example.numpy().dtype)],
+        outputs=[ct.TensorType(name="hidden_states", dtype=np.float16)],
+        convert_to="mlprogram",
+        compute_precision=ct.precision.FLOAT16,
+        minimum_deployment_target=minimum_target(deployment_target),
+    )
+
+    output_path = pathlib.Path(output_path).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        if output_path.is_dir():
+            import shutil
+
+            shutil.rmtree(output_path)
+        else:
+            output_path.unlink()
+    mlmodel.save(str(output_path))
+    print(output_path, flush=True)
+    return output_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        export_gpt2_coreml(
+            weights_dir=pathlib.Path(args.weights),
+            output_path=pathlib.Path(args.output),
+            seq_len=args.seq_len,
+            model_id=args.model,
+            cache_dir=args.cache_dir,
+            deployment_target=args.minimum_target,
+        )
+    except Exception as exc:  # pragma: no cover - surfaced to espresso-generate
+        print(f"export_gpt2_coreml failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_gpt2_coreml_reference.py
+++ b/scripts/run_gpt2_coreml_reference.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Run GPT-2 Core ML compare baselines for espresso-generate.
+
+Non-streaming mode prints one JSON object matching CoreMLComparisonResult.
+With `--emit-events`, prints NDJSON events: compile / token / completed.
+
+Requires: numpy, coremltools (macOS). Final LayerNorm + LM head are applied from
+Espresso weight blobs so the Core ML package only needs to emit trunk hidden states.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import struct
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+BLOBFILE_HEADER_BYTES = 128
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--coreml-model", required=True, help="Path to gpt2_seqN.mlpackage")
+    parser.add_argument("--weights", required=True, help="Espresso GPT-2 weights directory")
+    parser.add_argument(
+        "--prompt-tokens",
+        required=True,
+        help="Comma-separated prompt token ids",
+    )
+    parser.add_argument("--seq-len", required=True, type=int)
+    parser.add_argument("--max-tokens", required=True, type=int)
+    parser.add_argument("--temperature", required=True, type=float)
+    parser.add_argument("--warmup", required=True, type=int)
+    parser.add_argument("--iterations", required=True, type=int)
+    parser.add_argument("--seed", required=True, type=int)
+    parser.add_argument("--compute-units", required=True)
+    parser.add_argument(
+        "--emit-events",
+        action="store_true",
+        help="Emit NDJSON stream events instead of a single JSON object",
+    )
+    args = parser.parse_args(argv)
+    args.prompt_tokens = parse_prompt_tokens(args.prompt_tokens)
+    return args
+
+
+def parse_prompt_tokens(raw: str) -> list[int]:
+    tokens: list[int] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        tokens.append(int(part))
+    if not tokens:
+        raise ValueError("prompt-tokens must contain at least one token id")
+    return tokens
+
+
+def build_comparison_result(
+    *,
+    generated_tokens: list[int],
+    compile_time_ms: float,
+    first_token_latency_ms: float,
+    tokens_per_second: float,
+    median_token_ms: float,
+    p95_token_ms: float,
+    token_latencies_ms: list[float],
+    total_time_ms: float,
+    compute_units: str,
+    seq_len: int,
+) -> dict[str, Any]:
+    return {
+        "generated_tokens": generated_tokens,
+        "compile_time_ms": compile_time_ms,
+        "first_token_latency_ms": first_token_latency_ms,
+        "tokens_per_second": tokens_per_second,
+        "median_token_ms": median_token_ms,
+        "p95_token_ms": p95_token_ms,
+        "token_latencies_ms": token_latencies_ms,
+        "total_time_ms": total_time_ms,
+        "compute_units": compute_units,
+        "seq_len": seq_len,
+    }
+
+
+def _load_blobfile(path: Path) -> np.ndarray:
+    data = path.read_bytes()
+    if len(data) < BLOBFILE_HEADER_BYTES:
+        raise ValueError(f"BLOBFILE too small: {path}")
+    payload_size = struct.unpack_from("<I", data, 72)[0]
+    payload = data[BLOBFILE_HEADER_BYTES : BLOBFILE_HEADER_BYTES + payload_size]
+    if len(payload) != payload_size:
+        raise ValueError(f"BLOBFILE truncated: {path}")
+    return np.frombuffer(payload, dtype=np.float16).astype(np.float32)
+
+
+def load_top_level_weights(weights_dir: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    gamma_candidates = ["final_norm_gamma.bin", "ln_f_gamma.bin", "final_norm.bin"]
+    beta_candidates = ["final_norm_beta.bin", "ln_f_beta.bin"]
+    head_candidates = ["lm_head.bin", "classifier.bin"]
+
+    def first_existing(names: list[str]) -> Path:
+        for name in names:
+            candidate = weights_dir / name
+            if candidate.is_file():
+                return candidate
+        raise FileNotFoundError(f"Missing one of {names} under {weights_dir}")
+
+    gamma = _load_blobfile(first_existing(gamma_candidates))
+    beta = _load_blobfile(first_existing(beta_candidates))
+    lm_head = _load_blobfile(first_existing(head_candidates))
+    if lm_head.size % gamma.size != 0:
+        raise ValueError("lm_head size is not divisible by hidden size")
+    return gamma, beta, lm_head.reshape(-1, gamma.size)
+
+
+def layer_norm(hidden: np.ndarray, gamma: np.ndarray, beta: np.ndarray, eps: float = 1e-5) -> np.ndarray:
+    mean = hidden.mean()
+    var = ((hidden - mean) ** 2).mean()
+    normalized = (hidden - mean) / math.sqrt(float(var) + eps)
+    return normalized * gamma + beta
+
+
+def sample_token(logits: np.ndarray, temperature: float, rng: np.random.Generator) -> int:
+    if temperature <= 0:
+        return int(np.argmax(logits))
+    scaled = logits / temperature
+    scaled = scaled - scaled.max()
+    probs = np.exp(scaled)
+    probs = probs / probs.sum()
+    return int(rng.choice(len(probs), p=probs))
+
+
+def percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    index = min(len(ordered) - 1, max(0, int(round(q * (len(ordered) - 1)))))
+    return ordered[index]
+
+
+def map_compute_units(name: str):
+    import coremltools as ct
+
+    mapping = {
+        "all": ct.ComputeUnit.ALL,
+        "cpu_only": ct.ComputeUnit.CPU_ONLY,
+        "cpu_and_gpu": ct.ComputeUnit.CPU_AND_GPU,
+        "cpu_and_ne": ct.ComputeUnit.CPU_AND_NE,
+        "cpu_and_neural_engine": ct.ComputeUnit.CPU_AND_NE,
+    }
+    key = name.lower()
+    if key not in mapping:
+        raise ValueError(f"Unsupported compute units: {name}")
+    return mapping[key]
+
+
+def run_reference(args: argparse.Namespace) -> dict[str, Any]:
+    import coremltools as ct
+
+    prompt_tokens = list(args.prompt_tokens)
+    if args.max_tokens <= 0:
+        raise ValueError("--max-tokens must be > 0")
+    if len(prompt_tokens) + args.max_tokens > args.seq_len:
+        raise ValueError("prompt + max-tokens exceeds --seq-len")
+
+    weights_dir = Path(args.weights).expanduser().resolve()
+    gamma, beta, lm_head = load_top_level_weights(weights_dir)
+
+    compile_start = time.perf_counter()
+    model = ct.models.MLModel(str(Path(args.coreml_model).expanduser()), compute_units=map_compute_units(args.compute_units))
+    compile_time_ms = (time.perf_counter() - compile_start) * 1000.0
+
+    input_name = model.input_description._fd_spec[0].name  # type: ignore[attr-defined]
+    output_name = model.output_description._fd_spec[0].name  # type: ignore[attr-defined]
+    model_seq = int(model.get_spec().description.input[0].type.multiArrayType.shape[1])
+    if args.seq_len > model_seq:
+        raise ValueError(f"Requested seq-len {args.seq_len} exceeds model capacity {model_seq}")
+
+    def predict_hidden(token_ids: list[int]) -> np.ndarray:
+        padded = np.zeros((1, model_seq), dtype=np.int32)
+        padded[0, : len(token_ids)] = np.asarray(token_ids, dtype=np.int32)
+        outputs = model.predict({input_name: padded})
+        hidden = np.asarray(outputs[output_name], dtype=np.float32)
+        # Accept [1, S, H] or [1, H, 1, S]-style layouts by normalizing to [S, H].
+        if hidden.ndim == 4 and hidden.shape[1] == gamma.size:
+            # [1, H, 1, S] → [S, H]
+            hidden = np.transpose(hidden[0, :, 0, :], (1, 0))
+        elif hidden.ndim == 3:
+            hidden = hidden[0]
+        else:
+            raise ValueError(f"Unexpected Core ML hidden shape: {hidden.shape}")
+        index = len(token_ids) - 1
+        return hidden[index]
+
+    def run_once(emit) -> tuple[list[int], list[float], float, float]:
+        rng = np.random.default_rng(args.seed)
+        generated: list[int] = []
+        latencies: list[float] = []
+        context = list(prompt_tokens)
+        total_start = time.perf_counter()
+
+        step_start = time.perf_counter()
+        hidden = predict_hidden(context)
+        normed = layer_norm(hidden, gamma, beta)
+        logits = lm_head @ normed
+        token = sample_token(logits, args.temperature, rng)
+        first_ms = (time.perf_counter() - step_start) * 1000.0
+        generated.append(token)
+        latencies.append(first_ms)
+        context.append(token)
+        if emit:
+            emit(
+                {
+                    "type": "token",
+                    "token": token,
+                    "token_index": 0,
+                    "elapsed_ms": first_ms,
+                    "token_latency_ms": first_ms,
+                    "tokens_per_second": 1000.0 / first_ms if first_ms > 0 else 0.0,
+                }
+            )
+
+        for index in range(1, args.max_tokens):
+            step_start = time.perf_counter()
+            hidden = predict_hidden(context)
+            normed = layer_norm(hidden, gamma, beta)
+            logits = lm_head @ normed
+            token = sample_token(logits, args.temperature, rng)
+            step_ms = (time.perf_counter() - step_start) * 1000.0
+            generated.append(token)
+            latencies.append(step_ms)
+            context.append(token)
+            elapsed = (time.perf_counter() - total_start) * 1000.0
+            if emit:
+                emit(
+                    {
+                        "type": "token",
+                        "token": token,
+                        "token_index": index,
+                        "elapsed_ms": elapsed,
+                        "token_latency_ms": step_ms,
+                        "tokens_per_second": (index + 1) * 1000.0 / elapsed if elapsed > 0 else 0.0,
+                    }
+                )
+
+        total_ms = (time.perf_counter() - total_start) * 1000.0
+        return generated, latencies, first_ms, total_ms
+
+    def emit_line(payload: dict[str, Any]) -> None:
+        print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+    if args.emit_events:
+        emit_line(
+            {
+                "type": "compile",
+                "compile_time_ms": compile_time_ms,
+                "compute_units": args.compute_units,
+                "seq_len": model_seq,
+            }
+        )
+
+    aggregated: list[float] = []
+    last: tuple[list[int], list[float], float, float] | None = None
+    for iteration in range(args.warmup + args.iterations):
+        emit = emit_line if args.emit_events and iteration == (args.warmup + args.iterations - 1) else None
+        measured = run_once(emit)
+        if iteration >= args.warmup:
+            last = measured
+            aggregated.extend(measured[1])
+
+    if last is None:
+        raise RuntimeError("No measured iteration completed")
+
+    generated_tokens, token_latencies_ms, first_token_latency_ms, total_time_ms = last
+    tokens_per_second = (
+        len(generated_tokens) * 1000.0 / total_time_ms if total_time_ms > 0 else 0.0
+    )
+    result = build_comparison_result(
+        generated_tokens=generated_tokens,
+        compile_time_ms=compile_time_ms,
+        first_token_latency_ms=first_token_latency_ms,
+        tokens_per_second=tokens_per_second,
+        median_token_ms=percentile(aggregated, 0.5),
+        p95_token_ms=percentile(aggregated, 0.95),
+        token_latencies_ms=token_latencies_ms,
+        total_time_ms=total_time_ms,
+        compute_units=args.compute_units,
+        seq_len=model_seq,
+    )
+
+    if args.emit_events:
+        completed = {"type": "completed", **result}
+        emit_line(completed)
+    else:
+        print(json.dumps(result), flush=True)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        run_reference(args)
+    except Exception as exc:  # pragma: no cover
+        print(f"run_gpt2_coreml_reference failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_gpt2_demo_helpers.py
+++ b/scripts/tests/test_gpt2_demo_helpers.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Contract tests for GPT-2 demo helper scripts required by espresso-generate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+
+
+def load_module(name: str, path: Path):
+    if not path.is_file():
+        raise unittest.SkipTest(f"missing helper script: {path.name}")
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class RequiredHelperScriptsExistTests(unittest.TestCase):
+    def test_required_demo_helpers_are_tracked(self) -> None:
+        required = [
+            "bootstrap_gpt2_demo.py",
+            "export_gpt2_coreml.py",
+            "run_gpt2_coreml_reference.py",
+            "assert_demo_helpers.py",
+        ]
+        missing = [name for name in required if not (SCRIPTS / name).is_file()]
+        self.assertEqual(missing, [], f"missing helper scripts: {missing}")
+
+
+class BootstrapGPT2DemoTests(unittest.TestCase):
+    def test_parse_args_requires_outputs(self) -> None:
+        bootstrap = load_module("bootstrap_gpt2_demo", SCRIPTS / "bootstrap_gpt2_demo.py")
+        with self.assertRaises(SystemExit):
+            bootstrap.parse_args([])
+
+    def test_bootstrap_writes_weights_and_tokenizer(self) -> None:
+        bootstrap = load_module("bootstrap_gpt2_demo", SCRIPTS / "bootstrap_gpt2_demo.py")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            weights_out = root / "weights"
+            tokenizer_out = root / "tokenizer"
+            cache_dir = root / "hf-cache"
+            cache_dir.mkdir()
+
+            vocab = {"!": 0, "a": 1}
+            merges = "#version: 0.2\na a"
+
+            class FakeTokenizer:
+                def __init__(self, *args, **kwargs):
+                    pass
+
+                @classmethod
+                def from_pretrained(cls, *args, **kwargs):
+                    return cls()
+
+                def save_pretrained(self, path: str) -> None:
+                    dest = Path(path)
+                    dest.mkdir(parents=True, exist_ok=True)
+                    (dest / "vocab.json").write_text(json.dumps(vocab), encoding="utf-8")
+                    (dest / "merges.txt").write_text(merges, encoding="utf-8")
+
+            def fake_convert(model_name, output_dir, cache_dir=None, metadata_name="gpt2_124m"):
+                output_dir = Path(output_dir)
+                output_dir.mkdir(parents=True, exist_ok=True)
+                (output_dir / "metadata.json").write_text(
+                    json.dumps({"name": metadata_name, "architecture": "gpt2"}),
+                    encoding="utf-8",
+                )
+                payload = struct.pack("<f", 1.0)
+                header = bytearray(128)
+                header[0] = 0x01
+                header[4] = 0x02
+                header[64:68] = bytes([0xEF, 0xBE, 0xAD, 0xDE])
+                header[68] = 0x01
+                struct.pack_into("<I", header, 72, len(payload))
+                struct.pack_into("<I", header, 80, 128)
+                (output_dir / "lm_head.bin").write_bytes(bytes(header) + payload)
+
+            bootstrap.bootstrap_gpt2_demo(
+                model_name="gpt2",
+                weights_out=weights_out,
+                tokenizer_out=tokenizer_out,
+                cache_dir=cache_dir,
+                convert_pretrained_gpt2=fake_convert,
+                GPT2Tokenizer=FakeTokenizer,
+            )
+
+            self.assertTrue((weights_out / "metadata.json").is_file())
+            self.assertTrue((tokenizer_out / "vocab.json").is_file())
+            self.assertTrue((tokenizer_out / "merges.txt").is_file())
+            self.assertEqual(json.loads((tokenizer_out / "vocab.json").read_text())["a"], 1)
+
+
+class ExportGPT2CoreMLTests(unittest.TestCase):
+    def test_parse_args_matches_swift_invocation(self) -> None:
+        export = load_module("export_gpt2_coreml", SCRIPTS / "export_gpt2_coreml.py")
+        args = export.parse_args(
+            [
+                "--weights",
+                "/tmp/gpt2_124m",
+                "--output",
+                "/tmp/gpt2_seq64.mlpackage",
+                "--seq-len",
+                "64",
+            ]
+        )
+        self.assertEqual(args.weights, "/tmp/gpt2_124m")
+        self.assertEqual(args.output, "/tmp/gpt2_seq64.mlpackage")
+        self.assertEqual(args.seq_len, 64)
+
+
+class RunGPT2CoreMLReferenceTests(unittest.TestCase):
+    def test_parse_args_matches_swift_invocation(self) -> None:
+        reference = load_module("run_gpt2_coreml_reference", SCRIPTS / "run_gpt2_coreml_reference.py")
+        args = reference.parse_args(
+            [
+                "--coreml-model",
+                "/tmp/model.mlpackage",
+                "--weights",
+                "/tmp/weights",
+                "--prompt-tokens",
+                "15496,995",
+                "--seq-len",
+                "64",
+                "--max-tokens",
+                "8",
+                "--temperature",
+                "0",
+                "--warmup",
+                "1",
+                "--iterations",
+                "2",
+                "--seed",
+                "1234",
+                "--compute-units",
+                "cpu_and_neural_engine",
+                "--emit-events",
+            ]
+        )
+        self.assertEqual(args.prompt_tokens, [15496, 995])
+        self.assertTrue(args.emit_events)
+
+    def test_result_payload_matches_swift_decoder_keys(self) -> None:
+        reference = load_module("run_gpt2_coreml_reference", SCRIPTS / "run_gpt2_coreml_reference.py")
+        payload = reference.build_comparison_result(
+            generated_tokens=[1, 2, 3],
+            compile_time_ms=12.5,
+            first_token_latency_ms=3.0,
+            tokens_per_second=40.0,
+            median_token_ms=25.0,
+            p95_token_ms=30.0,
+            token_latencies_ms=[25.0, 25.0, 30.0],
+            total_time_ms=80.0,
+            compute_units="cpu_only",
+            seq_len=64,
+        )
+        required = {
+            "generated_tokens",
+            "compile_time_ms",
+            "first_token_latency_ms",
+            "tokens_per_second",
+            "median_token_ms",
+            "p95_token_ms",
+            "token_latencies_ms",
+            "total_time_ms",
+            "compute_units",
+            "seq_len",
+        }
+        self.assertTrue(required.issubset(payload.keys()))
+
+
+class AssertDemoHelpersTests(unittest.TestCase):
+    def test_assert_demo_helpers_passes_on_repo(self) -> None:
+        assert_helpers = load_module("assert_demo_helpers", SCRIPTS / "assert_demo_helpers.py")
+        self.assertEqual(assert_helpers.main(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the broken primary developer journey reported in #21: `./espresso` / `doctor` required helper scripts that were never tracked in git.

### Changes
- Add `scripts/bootstrap_gpt2_demo.py` — downloads/converts GPT-2 weights + tokenizer (`--weights-out`, `--tokenizer-out`, `--cache-dir`)
- Add `scripts/export_gpt2_coreml.py` — exports GPT-2 Core ML trunk for compare/bench (`--weights`, `--output`, `--seq-len`)
- Add `scripts/run_gpt2_coreml_reference.py` — optional Python Core ML reference runner matching Swift JSON contracts
- Add `scripts/assert_demo_helpers.py` + unit tests; CI fails if helpers disappear again
- Allowlist the new scripts in `.gitignore`
- Correct README / Examples / CONTRIBUTING / `espresso` help: `install` is a PATH shim; `prepare` / first demo run bootstrap weights
- Fix blog sample to use `RealModelInferenceEngine` instead of a non-existent async `ANEDirectGenerationModel.load(config:)` API

### Test plan
- [x] `python3 scripts/assert_demo_helpers.py`
- [x] `python3 scripts/tests/test_gpt2_demo_helpers.py -v`
- [ ] On Apple Silicon: `./espresso doctor` reports `scripts` OK
- [ ] On Apple Silicon: `./espresso prepare` bootstraps demo assets
- [ ] On Apple Silicon: `./espresso "Hello"` launches TUI after bootstrap

Closes #21

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff536-94b2-71cc-951d-120db41d23ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff536-94b2-71cc-951d-120db41d23ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

