### PR TITLE
refactor: own Qwen 1.5B shape and hops on the serve Layer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -202,7 +202,7 @@ let package = Package(
         ),
         .target(
             name: "RealModelInference",
-            dependencies: ["ModelSupport", "ANEGraphIR", "ANEBuilder", "ANECodegen", "ANEPasses", "ANERuntime", "ANETypes", "ANEInterop", "CPUOps", "Espresso"],
+            dependencies: ["ModelSupport", "ANEGraphIR", "ANEBuilder", "ANECodegen", "ANEPasses", "ANERuntime", "ANETypes", "ANEInterop", "CPUOps", "Espresso", "MILGenerator"],
             path: "Sources/RealModelInference",
             swiftSettings: [.swiftLanguageMode(.v6)],
             linkerSettings: [
@@ -235,7 +235,7 @@ let package = Package(
             name: "RealModelInferenceTests",
             dependencies: [
                 "RealModelInference", "ModelSupport", "ANEGraphIR", "ANETypes", "Espresso",
-                "ESPRuntime", "ESPBundle",
+                "ESPRuntime", "ESPBundle", "MILGenerator", "ANERuntime",
             ],
             path: "Tests/RealModelInferenceTests",
             resources: [.copy("Fixtures")],

--- a/Sources/ANERuntime/FusedHybridDecodeBlockKernelSet.swift
+++ b/Sources/ANERuntime/FusedHybridDecodeBlockKernelSet.swift
@@ -17,7 +17,10 @@ public struct FusedHybridDecodeBlockCompileReport: Sendable {
     public let errorDescription: String?
 
     public var hopsPerToken: Int {
-        FusedHybridDecodeBlockGenerator.hopsPerToken(layerCount: layerCount)
+        FusedHybridDecodeLayerGenerator.hopsPerToken(
+            nLayer: FusedHybridDecodeLayerGenerator.Qwen15BShape.nLayer,
+            blockSize: layerCount
+        )
     }
 }
 
@@ -52,10 +55,10 @@ public enum FusedHybridDecodeBlockKernelSet {
     }
 
     public static func dummyQwen15BWeightBlobs(layerCount: Int, value: Float = 0.01) -> [(path: String, data: Data)] {
-        let dim = FusedHybridDecodeBlockGenerator.Qwen15BShape.dModel
-        let qDim = FusedHybridDecodeBlockGenerator.Qwen15BShape.qDim
-        let kvDim = FusedHybridDecodeBlockGenerator.Qwen15BShape.kvDim
-        let hidden = FusedHybridDecodeBlockGenerator.Qwen15BShape.hiddenDim
+        let dim = FusedHybridDecodeLayerGenerator.Qwen15BShape.dModel
+        let qDim = FusedHybridDecodeLayerGenerator.Qwen15BShape.qDim
+        let kvDim = FusedHybridDecodeLayerGenerator.Qwen15BShape.kvDim
+        let hidden = FusedHybridDecodeLayerGenerator.Qwen15BShape.hiddenDim
         var blobs: [(path: String, data: Data)] = []
         blobs.reserveCapacity(layerCount * 11)
         for layer in 0..<layerCount {

--- a/Sources/ANERuntime/FusedHybridDecodeLayerKernelSet.swift
+++ b/Sources/ANERuntime/FusedHybridDecodeLayerKernelSet.swift
@@ -4,16 +4,8 @@ import ANETypes
 import MILGenerator
 
 /// One compiled Phase-11 `max_N = 1` fused layer (QKV + attention + FFN).
+/// Shape, hops, and the `fused` path label live on `FusedHybridDecodeLayerGenerator`.
 public struct FusedHybridDecodeLayerKernelSet: ~Copyable {
-    public static let phase11MaxN = 1
-    public static let decodePathLabel = "fused"
-    public static let fallbackStage = "fused_hybrid_decode"
-
-    public static func hopsPerToken(nLayer: Int, blockSize: Int = phase11MaxN) -> Int {
-        precondition(nLayer > 0 && blockSize > 0)
-        return (nLayer + blockSize - 1) / blockSize
-    }
-
     public struct DonorHexIDs: Sendable {
         public let fusedLayer: String
     }

--- a/Sources/MILGenerator/FusedHybridDecodeBlockGenerator.swift
+++ b/Sources/MILGenerator/FusedHybridDecodeBlockGenerator.swift
@@ -8,21 +8,8 @@ import ANEGraphIR
 /// Attention / RoPE stay off this graph (Metal). Each stacked layer is:
 /// RMSNorm → QKV(+bias) → zero-scale keep-alive → RMSNorm → SwiGLU FFN → residual.
 /// Stories recurrent fusion is a different graph and does not count as a pass.
+/// Shape and hops live on `FusedHybridDecodeLayerGenerator`.
 public struct FusedHybridDecodeBlockGenerator: MILProgramGenerator {
-    public enum Qwen15BShape {
-        public static let nLayer = 28
-        public static let dModel = 1536
-        public static let nHead = 12
-        public static let nKVHead = 2
-        public static let headDim = 128
-        public static let hiddenDim = 8960
-        public static let qDim = dModel
-        public static let kvDim = nKVHead * headDim
-        public static let ropeTheta: Float = 1_000_000
-        public static let normEps: Float = 1e-6
-        public static let laneSpatial = 32
-    }
-
     public let layerCount: Int
     public let dim: Int
     public let qDim: Int
@@ -38,8 +25,8 @@ public struct FusedHybridDecodeBlockGenerator: MILProgramGenerator {
         qDim: Int,
         kvDim: Int,
         hiddenDim: Int,
-        laneSpatial: Int = Qwen15BShape.laneSpatial,
-        normEps: Float = Qwen15BShape.normEps,
+        laneSpatial: Int = FusedHybridDecodeLayerGenerator.Qwen15BShape.laneSpatial,
+        normEps: Float = FusedHybridDecodeLayerGenerator.Qwen15BShape.normEps,
         hasQKVBias: Bool = true
     ) {
         precondition(layerCount > 0)
@@ -55,22 +42,21 @@ public struct FusedHybridDecodeBlockGenerator: MILProgramGenerator {
         self.hasQKVBias = hasQKVBias
     }
 
-    public static func qwen15B(layerCount: Int, laneSpatial: Int = Qwen15BShape.laneSpatial) -> Self {
-        Self(
+    public static func qwen15B(
+        layerCount: Int,
+        laneSpatial: Int = FusedHybridDecodeLayerGenerator.Qwen15BShape.laneSpatial
+    ) -> Self {
+        let shape = FusedHybridDecodeLayerGenerator.Qwen15BShape.self
+        return Self(
             layerCount: layerCount,
-            dim: Qwen15BShape.dModel,
-            qDim: Qwen15BShape.qDim,
-            kvDim: Qwen15BShape.kvDim,
-            hiddenDim: Qwen15BShape.hiddenDim,
+            dim: shape.dModel,
+            qDim: shape.qDim,
+            kvDim: shape.kvDim,
+            hiddenDim: shape.hiddenDim,
             laneSpatial: laneSpatial,
-            normEps: Qwen15BShape.normEps,
+            normEps: shape.normEps,
             hasQKVBias: true
         )
-    }
-
-    public static func hopsPerToken(layerCount: Int, modelLayers: Int = Qwen15BShape.nLayer) -> Int {
-        precondition(layerCount > 0)
-        return (modelLayers + layerCount - 1) / layerCount
     }
 
     public var inputBytes: Int { dim * laneSpatial * 2 }

--- a/Sources/MILGenerator/FusedHybridDecodeLayerGenerator.swift
+++ b/Sources/MILGenerator/FusedHybridDecodeLayerGenerator.swift
@@ -10,7 +10,24 @@ import ANEGraphIR
 /// Inputs (alphabetical): kCache, mask, posMask, ropePack, vCache, x
 /// Outputs (alphabetical): kNew, vNew, xOut
 public struct FusedHybridDecodeLayerGenerator: MILProgramGenerator {
+    /// Qwen2.5-1.5B-Instruct widths for the serve Layer graph. The Block
+    /// compile probe reads this catalog; it does not own it.
+    public enum Qwen15BShape {
+        public static let nLayer = 28
+        public static let dModel = 1536
+        public static let nHead = 12
+        public static let nKVHead = 2
+        public static let headDim = 128
+        public static let hiddenDim = 8960
+        public static let qDim = dModel
+        public static let kvDim = nKVHead * headDim
+        public static let ropeTheta: Float = 1_000_000
+        public static let normEps: Float = 1e-6
+        public static let laneSpatial = 32
+    }
+
     public static let phase11MaxN = 1
+    public static let decodePathLabel = "fused"
 
     public let dim: Int
     public let qDim: Int
@@ -33,8 +50,8 @@ public struct FusedHybridDecodeLayerGenerator: MILProgramGenerator {
         nKVHeads: Int,
         headDim: Int,
         maxSeq: Int,
-        laneSpatial: Int = FusedHybridDecodeBlockGenerator.Qwen15BShape.laneSpatial,
-        normEps: Float = FusedHybridDecodeBlockGenerator.Qwen15BShape.normEps,
+        laneSpatial: Int = Qwen15BShape.laneSpatial,
+        normEps: Float = Qwen15BShape.normEps,
         hasQKVBias: Bool = true
     ) {
         precondition(dim > 0 && qDim > 0 && kvDim > 0 && hiddenDim > 0)
@@ -56,9 +73,9 @@ public struct FusedHybridDecodeLayerGenerator: MILProgramGenerator {
 
     public static func qwen15B(
         maxSeq: Int,
-        laneSpatial: Int = FusedHybridDecodeBlockGenerator.Qwen15BShape.laneSpatial
+        laneSpatial: Int = Qwen15BShape.laneSpatial
     ) -> Self {
-        let shape = FusedHybridDecodeBlockGenerator.Qwen15BShape.self
+        let shape = Qwen15BShape.self
         return Self(
             dim: shape.dModel,
             qDim: shape.qDim,
@@ -75,7 +92,7 @@ public struct FusedHybridDecodeLayerGenerator: MILProgramGenerator {
     }
 
     public static func hopsPerToken(
-        nLayer: Int = FusedHybridDecodeBlockGenerator.Qwen15BShape.nLayer,
+        nLayer: Int = Qwen15BShape.nLayer,
         blockSize: Int = phase11MaxN
     ) -> Int {
         precondition(nLayer > 0 && blockSize > 0)

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -238,9 +238,6 @@ public struct RealModelInferenceEngine: ~Copyable {
 
     /// Phase 11 compiled `max_N = 1` only. Serve that N: one fused program per
     /// layer with attention in-graph (28 hops, no Metal QKV↔FFN sync).
-    static let fusedDecodePathLabel = FusedHybridDecodeLayerKernelSet.decodePathLabel
-    static let fusedHybridFallbackStage = FusedHybridDecodeLayerKernelSet.fallbackStage
-
     static func prefersFusedHybridDecode(
         config: MultiModelConfig,
         environment: [String: String]
@@ -254,12 +251,8 @@ public struct RealModelInferenceEngine: ~Copyable {
         return config.architecture == .llama && ModelFamily.isQwen15BVariant(config)
     }
 
-    static func fusedHopsPerToken(nLayer: Int) -> Int {
-        FusedHybridDecodeLayerKernelSet.hopsPerToken(nLayer: nLayer)
-    }
-
     static func fusedHybridFallbackError(reason: String) -> RealModelInferenceError {
-        .hybridFallbackDisabled(stage: fusedHybridFallbackStage, reason: reason)
+        .hybridFallbackDisabled(stage: "fused_hybrid_decode", reason: reason)
     }
 
     static func makeHybridCachedBindingsOrFallback<Bindings>(
@@ -1650,8 +1643,8 @@ public struct RealModelInferenceEngine: ~Copyable {
                     decodePath = "exact_cpu"
                     hopsPerToken = nil
                 } else if Self.prefersFusedHybridDecode(config: config, environment: environment) {
-                    decodePath = Self.fusedDecodePathLabel
-                    hopsPerToken = Self.fusedHopsPerToken(nLayer: config.nLayer)
+                    decodePath = FusedHybridDecodeLayerGenerator.decodePathLabel
+                    hopsPerToken = FusedHybridDecodeLayerGenerator.hopsPerToken(nLayer: config.nLayer)
                 } else {
                     decodePath = "hybrid"
                     hopsPerToken = nil
@@ -6009,7 +6002,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             throw Self.fusedHybridFallbackError(reason: "fused decode state initialization failed: \(error)")
         }
         var timings = HybridDecodeTimingBreakdown()
-        let hopsPerToken = Self.fusedHopsPerToken(nLayer: config.nLayer)
+        let hopsPerToken = FusedHybridDecodeLayerGenerator.hopsPerToken(nLayer: config.nLayer)
 
         for (position, token) in promptTokens.enumerated() {
             try writeIncrementalEmbeddingLlama(token: token, into: xCur)
@@ -6140,7 +6133,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
             cachedBindingsEnabled: false,
-            decodePath: Self.fusedDecodePathLabel,
+            decodePath: FusedHybridDecodeLayerGenerator.decodePathLabel,
             hopsPerToken: hopsPerToken,
             decodeProfileReport: decodeProfileReport
         )

--- a/Tests/ANERuntimeTests/FusedQwen15BDecodeCompileProbeTests.swift
+++ b/Tests/ANERuntimeTests/FusedQwen15BDecodeCompileProbeTests.swift
@@ -94,7 +94,7 @@ final class FusedHybridDecodeBlockSpecTests: XCTestCase {
         XCTAssertTrue(spec.milText.contains("func main<ios18>"))
         XCTAssertTrue(spec.milText.contains("l0_bq.bin"))
         XCTAssertGreaterThan(spec.weightBlobBytes, 80_000_000)
-        XCTAssertEqual(FusedHybridDecodeBlockGenerator.hopsPerToken(layerCount: 1), 28)
+        XCTAssertEqual(FusedHybridDecodeLayerGenerator.hopsPerToken(nLayer: 28, blockSize: 1), 28)
     }
 }
 

--- a/Tests/MILGeneratorTests/FusedHybridDecodeBlockGeneratorTests.swift
+++ b/Tests/MILGeneratorTests/FusedHybridDecodeBlockGeneratorTests.swift
@@ -29,7 +29,6 @@ final class FusedHybridDecodeBlockGeneratorTests: XCTestCase {
         XCTAssertFalse(mil.contains("tanh"), "Tanh SiLU identity must stay opt-in")
         XCTAssertEqual(gen.inputByteSizes, [1536 * 32 * 2])
         XCTAssertEqual(gen.outputByteSizes, [1536 * 32 * 2])
-        XCTAssertEqual(FusedHybridDecodeBlockGenerator.hopsPerToken(layerCount: 1), 28)
     }
 
     func test_qwen15b_n2_emits_two_layer_weight_prefixes() {
@@ -40,9 +39,6 @@ final class FusedHybridDecodeBlockGeneratorTests: XCTestCase {
         XCTAssertTrue(mil.contains("l1_w1.bin"))
         XCTAssertTrue(mil.contains("l0_bq.bin"))
         XCTAssertTrue(mil.contains("l1_bq.bin"))
-        XCTAssertEqual(FusedHybridDecodeBlockGenerator.hopsPerToken(layerCount: 2), 14)
-        XCTAssertEqual(FusedHybridDecodeBlockGenerator.hopsPerToken(layerCount: 4), 7)
-        XCTAssertEqual(FusedHybridDecodeBlockGenerator.hopsPerToken(layerCount: 7), 4)
     }
 
     func test_ssa_names_are_unique_for_n4() {
@@ -61,19 +57,5 @@ final class FusedHybridDecodeBlockGeneratorTests: XCTestCase {
             }
         }
         XCTAssertEqual(names.count, Set(names).count, "Duplicate SSA names in N=4 fused block")
-    }
-
-    func test_shape_constants_match_qwen15b_contract() {
-        let shape = FusedHybridDecodeBlockGenerator.Qwen15BShape.self
-        XCTAssertEqual(shape.nLayer, 28)
-        XCTAssertEqual(shape.dModel, 1536)
-        XCTAssertEqual(shape.nHead, 12)
-        XCTAssertEqual(shape.nKVHead, 2)
-        XCTAssertEqual(shape.headDim, 128)
-        XCTAssertEqual(shape.hiddenDim, 8960)
-        XCTAssertEqual(shape.qDim, 1536)
-        XCTAssertEqual(shape.kvDim, 256)
-        XCTAssertEqual(shape.ropeTheta, 1_000_000)
-        XCTAssertEqual(shape.normEps, 1e-6)
     }
 }

--- a/Tests/MILGeneratorTests/FusedHybridDecodeLayerGeneratorTests.swift
+++ b/Tests/MILGeneratorTests/FusedHybridDecodeLayerGeneratorTests.swift
@@ -21,6 +21,27 @@ final class FusedHybridDecodeLayerGeneratorTests: XCTestCase {
         XCTAssertEqual(gen.outputByteSizes.count, 3)
         XCTAssertEqual(FusedHybridDecodeLayerGenerator.hopsPerToken(nLayer: 28), 28)
         XCTAssertEqual(FusedHybridDecodeLayerGenerator.phase11MaxN, 1)
+        XCTAssertEqual(FusedHybridDecodeLayerGenerator.decodePathLabel, "fused")
+    }
+
+    func test_qwen15b_shape_catalog_and_hops_live_on_layer() {
+        let shape = FusedHybridDecodeLayerGenerator.Qwen15BShape.self
+        XCTAssertEqual(shape.nLayer, 28)
+        XCTAssertEqual(shape.dModel, 1536)
+        XCTAssertEqual(shape.nHead, 12)
+        XCTAssertEqual(shape.nKVHead, 2)
+        XCTAssertEqual(shape.headDim, 128)
+        XCTAssertEqual(shape.hiddenDim, 8960)
+        XCTAssertEqual(shape.qDim, 1536)
+        XCTAssertEqual(shape.kvDim, 256)
+        XCTAssertEqual(shape.ropeTheta, 1_000_000)
+        XCTAssertEqual(shape.normEps, 1e-6)
+        XCTAssertEqual(shape.laneSpatial, 32)
+        XCTAssertEqual(FusedHybridDecodeLayerGenerator.hopsPerToken(), 28)
+        XCTAssertEqual(FusedHybridDecodeLayerGenerator.hopsPerToken(nLayer: 28, blockSize: 1), 28)
+        XCTAssertEqual(FusedHybridDecodeLayerGenerator.hopsPerToken(nLayer: 28, blockSize: 2), 14)
+        XCTAssertEqual(FusedHybridDecodeLayerGenerator.hopsPerToken(nLayer: 28, blockSize: 4), 7)
+        XCTAssertEqual(FusedHybridDecodeLayerGenerator.hopsPerToken(nLayer: 28, blockSize: 7), 4)
     }
 
     func test_input_and_output_names_are_alphabetical() {

--- a/Tests/RealModelInferenceTests/FusedQwen15BDecodeServeCompileTests.swift
+++ b/Tests/RealModelInferenceTests/FusedQwen15BDecodeServeCompileTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Foundation
 import ANERuntime
 import ESPRuntime
+import MILGenerator
 import ModelSupport
 @testable import RealModelInference
 
@@ -45,9 +46,8 @@ final class FusedQwen15BDecodeServeCompileTests: XCTestCase {
         XCTAssertEqual(kernels.dim, 1536)
         XCTAssertEqual(kernels.kvDim, 256)
         XCTAssertEqual(kernels.maxSeq, 32)
-        XCTAssertEqual(FusedHybridDecodeLayerKernelSet.phase11MaxN, 1)
-        XCTAssertEqual(FusedHybridDecodeLayerKernelSet.hopsPerToken(nLayer: 28), 28)
-        XCTAssertEqual(FusedHybridDecodeLayerKernelSet.decodePathLabel, "fused")
-        XCTAssertEqual(FusedHybridDecodeLayerKernelSet.fallbackStage, "fused_hybrid_decode")
+        XCTAssertEqual(FusedHybridDecodeLayerGenerator.phase11MaxN, 1)
+        XCTAssertEqual(FusedHybridDecodeLayerGenerator.hopsPerToken(nLayer: 28), 28)
+        XCTAssertEqual(FusedHybridDecodeLayerGenerator.decodePathLabel, "fused")
     }
 }

--- a/Tests/RealModelInferenceTests/HybridLlamaDecodeStepTests.swift
+++ b/Tests/RealModelInferenceTests/HybridLlamaDecodeStepTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import ANETypes
+import MILGenerator
 import ModelSupport
 @testable import RealModelInference
 
@@ -381,8 +382,8 @@ import ModelSupport
             environment: ["ESPRESSO_ENABLE_FUSED_HYBRID_DECODE": "1"]
         ) == true
     )
-    #expect(RealModelInferenceEngine.fusedHopsPerToken(nLayer: 28) == 28)
-    #expect(RealModelInferenceEngine.fusedDecodePathLabel == "fused")
+    #expect(FusedHybridDecodeLayerGenerator.hopsPerToken(nLayer: 28) == 28)
+    #expect(FusedHybridDecodeLayerGenerator.decodePathLabel == "fused")
     let missing = RealModelInferenceEngine.fusedHybridFallbackError(reason: "missing N=1 kernel")
     guard case let .hybridFallbackDisabled(stage, reason) = missing else {
         Issue.record("expected hybridFallbackDisabled, got \(missing)")

--- a/Tests/RealModelInferenceTests/QwenParityExactMatchTests.swift
+++ b/Tests/RealModelInferenceTests/QwenParityExactMatchTests.swift
@@ -2,6 +2,7 @@ import ANETypes
 import Darwin
 import ESPRuntime
 import Foundation
+import MILGenerator
 import ModelSupport
 import Testing
 @testable import RealModelInference
@@ -389,10 +390,10 @@ private func assertQwenGreedyParityMatchesPyTorchReferenceOnANE(
     }
     #expect(snapshots.count == cases.count + 2)
     let expectedDecodePath = ModelFamily.isQwen15BVariant(config)
-        ? RealModelInferenceEngine.fusedDecodePathLabel
+        ? FusedHybridDecodeLayerGenerator.decodePathLabel
         : "hybrid"
     #expect(snapshots.allSatisfy { $0.decodePath == expectedDecodePath })
-    if expectedDecodePath == RealModelInferenceEngine.fusedDecodePathLabel {
+    if expectedDecodePath == FusedHybridDecodeLayerGenerator.decodePathLabel {
         #expect(snapshots.allSatisfy { $0.hopsPerToken == 28 })
         #expect(snapshots.allSatisfy { $0.cachedBindingsEnabled == false })
         #expect(snapshots.allSatisfy { $0.exactHeadBackend == "cpu_fp16_tiled" })


### PR DESCRIPTION
## Summary

Qwen 1.5B widths, hops/token, and the `fused` path label now live on `FusedHybridDecodeLayerGenerator` (the serve Layer MIL module).

The Block graph stays a dummy-weight QKV+FFN compile probe and reads that catalog. `FusedHybridDecodeLayerKernelSet` and `RealModelInferenceEngine` no longer re-export hops/label/`phase11MaxN`. Generate/chat still report `fused` and 28 hops/token.

This is the first leftover from the 18 Aug architecture review: catalog ownership, not a new serve graph.

## Test plan

- [x] `swift test --filter "MILGeneratorTests|RealModelInferenceTests|EspressoGenerateTests|ModelSupportTests"`
- [x] `swift test --filter "ANETypesTests|CPUOpsTests|ANEGraphIRTests|ANECodegenTests|ANEPassesTests|ANEBuilderTests|DeltaCompilationTests|LoRAAdapterTests|MigrationParityTests|ESPBundleTests|ESPCompilerTests|ESPRuntimeTests|ESPConvertTests|ESPBenchSupportTests|ESPCompilerCLITests|ANERuntimeTests"`
- Hardware-gated serve compile (`ANE_HARDWARE_TESTS=1`) not re-run; compile path is unchanged