### PR TITLE
feat: include prefill in generate TTFT and add batched Qwen prefill/AMX share

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,7 @@ let package = Package(
                 .linkedFramework("Foundation"),
                 .linkedFramework("CoreML"),
                 .linkedFramework("IOSurface"),
+                .linkedFramework("Accelerate"),
                 .linkedLibrary("dl"),
             ]
         ),
@@ -125,7 +126,7 @@ let package = Package(
         ),
         .testTarget(
             name: "EspressoTests",
-            dependencies: ["Espresso", "CPUOps", "ANEInterop", "ANETypes"],
+            dependencies: ["Espresso", "CPUOps", "ANEInterop", "ANETypes", "ANERuntime"],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .testTarget(

--- a/Sources/ANEInterop/bnns_amx.c
+++ b/Sources/ANEInterop/bnns_amx.c
@@ -1,0 +1,109 @@
+#include "ane_interop.h"
+
+#include <Accelerate/Accelerate.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+int ane_interop_bnns_fp32_gemv(const float *weights,
+                               const float *input,
+                               float *out,
+                               int rows,
+                               int dim,
+                               int n_threads) {
+    if (weights == NULL || input == NULL || out == NULL || rows <= 0 || dim <= 0) {
+        return -1;
+    }
+
+    BNNSNDArrayDescriptor in_desc;
+    memset(&in_desc, 0, sizeof(in_desc));
+    in_desc.layout = BNNSDataLayoutVector;
+    in_desc.size[0] = (size_t)dim;
+    in_desc.data = (void *)(uintptr_t)input;
+    in_desc.data_type = BNNSDataTypeFloat32;
+    in_desc.data_scale = 1.0f;
+
+    BNNSNDArrayDescriptor w_desc;
+    memset(&w_desc, 0, sizeof(w_desc));
+    w_desc.layout = BNNSDataLayoutRowMajorMatrix;
+    w_desc.size[0] = (size_t)dim;
+    w_desc.size[1] = (size_t)rows;
+    w_desc.data = (void *)(uintptr_t)weights;
+    w_desc.data_type = BNNSDataTypeFloat32;
+    w_desc.data_scale = 1.0f;
+
+    BNNSNDArrayDescriptor out_desc;
+    memset(&out_desc, 0, sizeof(out_desc));
+    out_desc.layout = BNNSDataLayoutVector;
+    out_desc.size[0] = (size_t)rows;
+    out_desc.data = out;
+    out_desc.data_type = BNNSDataTypeFloat32;
+    out_desc.data_scale = 1.0f;
+
+    BNNSLayerParametersFullyConnected layer;
+    memset(&layer, 0, sizeof(layer));
+    layer.i_desc = in_desc;
+    layer.w_desc = w_desc;
+    layer.o_desc = out_desc;
+    layer.activation.function = BNNSActivationFunctionIdentity;
+
+    BNNSFilterParameters filter_params;
+    memset(&filter_params, 0, sizeof(filter_params));
+    filter_params.n_threads = n_threads > 0 ? (size_t)n_threads : 1;
+
+    BNNSFilter filter = BNNSFilterCreateLayerFullyConnected(&layer, &filter_params);
+    if (filter == NULL) {
+        return -1;
+    }
+    int rc = BNNSFilterApply(filter, input, out);
+    BNNSFilterDestroy(filter);
+    return rc == 0 ? 0 : -1;
+}
+
+int ane_interop_bnns_fp32_gemm(const float *a,
+                               const float *b,
+                               float *c,
+                               int m,
+                               int n,
+                               int k,
+                               int n_threads) {
+    if (a == NULL || b == NULL || c == NULL || m <= 0 || n <= 0 || k <= 0) {
+        return -1;
+    }
+    (void)n_threads;
+    cblas_sgemm(
+        CblasRowMajor,
+        CblasNoTrans,
+        CblasNoTrans,
+        m,
+        n,
+        k,
+        1.0f,
+        a,
+        k,
+        b,
+        n,
+        0.0f,
+        c,
+        n
+    );
+    return 0;
+}
+
+int ane_interop_amx_shared_resource_hint(int enable, int worker_index, int cluster_concurrency) {
+#ifdef SYS_bsdthread_ctl
+    long rc = syscall(
+        SYS_bsdthread_ctl,
+        (void *)(uintptr_t)0x2000,
+        (void *)(uintptr_t)(unsigned)enable,
+        (void *)(uintptr_t)(unsigned)worker_index,
+        (void *)(uintptr_t)(unsigned)cluster_concurrency
+    );
+    return rc == 0 ? 0 : -1;
+#else
+    (void)enable;
+    (void)worker_index;
+    (void)cluster_concurrency;
+    return -1;
+#endif
+}

--- a/Sources/ANEInterop/include/ane_interop.h
+++ b/Sources/ANEInterop/include/ane_interop.h
@@ -151,6 +151,26 @@ int ane_interop_fp16_gemv_argmax(const void *weights_f16,
                                  int vocab_size,
                                  int dim);
 
+/// FP32 GEMV via BNNS with `n_threads` (use 1 per AMX shard). Returns 0 on success.
+int ane_interop_bnns_fp32_gemv(const float *weights,
+                               const float *input,
+                               float *out,
+                               int rows,
+                               int dim,
+                               int n_threads);
+
+/// FP32 GEMM via BNNS: C[m,n] = A[m,k] * B[k,n], all row-major. `n_threads` 1 per shard.
+int ane_interop_bnns_fp32_gemm(const float *a,
+                               const float *b,
+                               float *c,
+                               int m,
+                               int n,
+                               int k,
+                               int n_threads);
+
+/// Best-effort `__bsdthread_ctl` shared-resource hint (0x2000). Returns 0 on success.
+int ane_interop_amx_shared_resource_hint(int enable, int worker_index, int cluster_concurrency);
+
 /// NEON-vectorized contiguous FP16 argmax. Returns index and value of the max
 /// element. On ties, the lowest index wins (first-max semantics).
 void ane_interop_neon_argmax_f16(const void *src, int count,

--- a/Sources/ANERuntime/ANEEvalTiming.swift
+++ b/Sources/ANERuntime/ANEEvalTiming.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Per-`eval()` wall time next to driver `lastHWExecutionTimeNS`.
+///
+/// `lastHWExecutionTimeNS` is 0 when perf stats are off or unsupported.
+public final class ANEEvalTimingRecorder: @unchecked Sendable {
+    public private(set) var lastWallNanoseconds: UInt64 = 0
+    public private(set) var lastWallMicroseconds: Double = 0
+    public private(set) var lastHWExecutionTimeNS: UInt64 = 0
+
+    public init() {}
+
+    public func record(wallNanoseconds: UInt64, hardwareNanoseconds: UInt64) {
+        lastWallNanoseconds = wallNanoseconds
+        lastWallMicroseconds = Double(wallNanoseconds) / 1_000.0
+        lastHWExecutionTimeNS = hardwareNanoseconds
+    }
+}

--- a/Sources/ANERuntime/ANEKernel.swift
+++ b/Sources/ANERuntime/ANEKernel.swift
@@ -69,6 +69,16 @@ public struct ANEKernel: ~Copyable {
 
     private let handle: OpaquePointer
     internal let hexId: String
+    private let evalTiming = ANEEvalTimingRecorder()
+
+    /// Host wall of the last successful `eval()`, microseconds.
+    public var lastEvalWallMicroseconds: Double { evalTiming.lastWallMicroseconds }
+    /// Host wall of the last successful `eval()`, nanoseconds.
+    public var lastEvalWallNanoseconds: UInt64 { evalTiming.lastWallNanoseconds }
+    /// Driver `lastHWExecutionTimeNS` captured with the last `eval()` (0 if perf stats off).
+    public var lastEvalHWExecutionTimeNS: UInt64 { evalTiming.lastHWExecutionTimeNS }
+    /// Same recorder `eval()` writes. Always-on tests drive this type without compiling a kernel.
+    public var evalTimingRecorder: ANEEvalTimingRecorder { evalTiming }
 
     @inline(__always)
     private static func checkedSurfaceIndex(_ index: Int) throws(ANEError) -> Int32 {
@@ -442,10 +452,17 @@ public struct ANEKernel: ~Copyable {
     /// Run the compiled kernel on ANE.
     /// Input data must be written to inputSurface before calling.
     /// Output data is available on outputSurface after return.
+    ///
+    /// Records host wall next to `lastHWExecutionTimeNS` on every successful eval.
     public func eval() throws(ANEError) {
+        let start = DispatchTime.now().uptimeNanoseconds
         guard ane_interop_eval(handle) else {
             throw .evaluationFailed
         }
+        evalTiming.record(
+            wallNanoseconds: DispatchTime.now().uptimeNanoseconds - start,
+            hardwareNanoseconds: lastHWExecutionTimeNS()
+        )
     }
 
     /// Last reported on-chip execution time from `_ANEPerformanceStats` (nanoseconds).

--- a/Sources/ANERuntime/HybridDecodeKernelSet.swift
+++ b/Sources/ANERuntime/HybridDecodeKernelSet.swift
@@ -174,6 +174,8 @@ public struct HybridDecodeKernelSet: ~Copyable {
         try self.init(weights: weights, maxSeq: maxSeq, donorHexIDs: nil, options: options)
     }
 
+    public static let prefillSequenceLengths: [Int] = [64, 256]
+
     package init(
         weights: borrowing LayerWeights,
         maxSeq: Int = ModelConfig.seqLen,
@@ -185,6 +187,9 @@ public struct HybridDecodeKernelSet: ~Copyable {
         }
         let resolvedOptions = options ?? .resolve()
         let laneSpatial = resolvedOptions.laneSpatial ?? DecodeKernelSet.defaultLaneSpatial
+        guard laneSpatial > 0 else {
+            throw .invalidArguments("hybrid decode laneSpatial must be > 0")
+        }
         let compiledQKV = try Self.compileDecodeQKVOnly(
             weights: weights,
             laneSpatial: laneSpatial,
@@ -237,6 +242,33 @@ public struct HybridDecodeKernelSet: ~Copyable {
             makeDecodeProjectionSpec(weights: weights, laneSpatial: laneSpatial),
             makeDecodeFFNSpec(weights: weights, laneSpatial: laneSpatial),
         ]
+    }
+
+    /// Fixed-shape Qwen prefill QKV/projection/FFN kernels at seq=64 and seq=256.
+    internal static func prefillCompileSpecs(
+        weights: borrowing LayerWeights,
+        sequenceLength: Int
+    ) -> [CompileSpec] {
+        precondition(prefillSequenceLengths.contains(sequenceLength))
+        return [
+            makeDecodeQKVOnlySpec(weights: weights, laneSpatial: sequenceLength),
+            makeDecodeProjectionSpec(weights: weights, laneSpatial: sequenceLength),
+            makeDecodeFFNSpec(weights: weights, laneSpatial: sequenceLength),
+        ]
+    }
+
+    public init(prefillWeights weights: borrowing LayerWeights, sequenceLength: Int) throws(ANEError) {
+        guard Self.prefillSequenceLengths.contains(sequenceLength) else {
+            throw .invalidArguments(
+                "Qwen prefill sequenceLength must be 64 or 256, got \(sequenceLength)"
+            )
+        }
+        try self.init(
+            weights: weights,
+            maxSeq: sequenceLength,
+            donorHexIDs: nil,
+            options: HybridDecodeKernelOptions(laneSpatial: sequenceLength)
+        )
     }
 
     private static func compileDecodeQKVOnly(

--- a/Sources/Espresso/FP16TiledClassifier.swift
+++ b/Sources/Espresso/FP16TiledClassifier.swift
@@ -1,5 +1,6 @@
 import Accelerate
 import ANEInterop
+import Dispatch
 
 /// FP16 tiled classifier: converts FP16 weights in L2-sized tiles, runs sgemm on L2-resident FP32 data.
 ///
@@ -167,5 +168,118 @@ public enum FP16TiledClassifier {
                 Int32(dim)
             )
         )
+    }
+
+    /// Isolated BNNS FP16 8-shard GEMV argmax. Same first-max rule as tiled/streaming.
+    public static let eightShardCount = 8
+
+    public static func shardRowRange(vocabSize: Int, shard: Int, shardCount: Int = eightShardCount) -> Range<Int> {
+        precondition(vocabSize > 0)
+        precondition(shardCount > 0)
+        precondition(shard >= 0 && shard < shardCount)
+        let base = vocabSize / shardCount
+        let rem = vocabSize % shardCount
+        let start = shard * base + min(shard, rem)
+        let count = base + (shard < rem ? 1 : 0)
+        return start..<(start + count)
+    }
+
+    @inline(__always)
+    public static func bnnsEightShardMatvecArgmax(
+        weights: UnsafePointer<UInt16>,
+        input: UnsafePointer<Float>,
+        vocabSize: Int,
+        dim: Int
+    ) -> Int {
+        precondition(vocabSize > 0)
+        precondition(dim > 0)
+        let shardCount = eightShardCount
+        let shardMax = UnsafeMutablePointer<Float>.allocate(capacity: shardCount)
+        let shardIdx = UnsafeMutablePointer<Int>.allocate(capacity: shardCount)
+        defer {
+            shardMax.deallocate()
+            shardIdx.deallocate()
+        }
+        for shard in 0..<shardCount {
+            shardMax[shard] = -.greatestFiniteMagnitude
+            shardIdx[shard] = 0
+        }
+
+        nonisolated(unsafe) let weightsPtr = weights
+        nonisolated(unsafe) let inputPtr = input
+        nonisolated(unsafe) let shardMaxPtr = shardMax
+        nonisolated(unsafe) let shardIdxPtr = shardIdx
+        DispatchQueue.concurrentPerform(iterations: shardCount) { shard in
+            let range = shardRowRange(vocabSize: vocabSize, shard: shard, shardCount: shardCount)
+            guard !range.isEmpty else { return }
+            _ = ane_interop_amx_shared_resource_hint(1, Int32(shard), 2)
+            defer { _ = ane_interop_amx_shared_resource_hint(0, Int32(shard), 2) }
+
+            let rows = range.count
+            let tileFP32 = UnsafeMutablePointer<Float>.allocate(capacity: rows * dim)
+            let logits = UnsafeMutablePointer<Float>.allocate(capacity: rows)
+            defer {
+                tileFP32.deallocate()
+                logits.deallocate()
+            }
+
+            let fp16Ptr = UnsafeMutableRawPointer(mutating: weightsPtr.advanced(by: range.lowerBound * dim))
+            var srcBuf = vImage_Buffer(
+                data: fp16Ptr,
+                height: 1,
+                width: vImagePixelCount(rows * dim),
+                rowBytes: rows * dim * MemoryLayout<UInt16>.stride
+            )
+            var dstBuf = vImage_Buffer(
+                data: UnsafeMutableRawPointer(tileFP32),
+                height: 1,
+                width: vImagePixelCount(rows * dim),
+                rowBytes: rows * dim * MemoryLayout<Float>.stride
+            )
+            vImageConvert_Planar16FtoPlanarF(&srcBuf, &dstBuf, 0)
+
+            let bnnsRC = ane_interop_bnns_fp32_gemv(
+                UnsafePointer(tileFP32),
+                inputPtr,
+                logits,
+                Int32(rows),
+                Int32(dim),
+                1
+            )
+            if bnnsRC != 0 {
+                BLAS.sgemm(
+                    CblasRowMajor,
+                    CblasNoTrans,
+                    CblasNoTrans,
+                    m: Int32(rows),
+                    n: 1,
+                    k: Int32(dim),
+                    alpha: 1.0,
+                    a: UnsafePointer(tileFP32),
+                    lda: Int32(dim),
+                    b: inputPtr,
+                    ldb: 1,
+                    beta: 0.0,
+                    c: logits,
+                    ldc: 1
+                )
+            }
+
+            var tileMax: Float = 0
+            var tileMaxIdx: vDSP_Length = 0
+            vDSP_maxvi(logits, 1, &tileMax, &tileMaxIdx, vDSP_Length(rows))
+            shardMaxPtr[shard] = tileMax
+            shardIdxPtr[shard] = range.lowerBound + Int(tileMaxIdx)
+        }
+
+        var bestValue: Float = -.greatestFiniteMagnitude
+        var bestIndex = 0
+        for shard in 0..<shardCount {
+            if shardMax[shard] > bestValue {
+                bestValue = shardMax[shard]
+                bestIndex = shardIdx[shard]
+            }
+        }
+        return bestIndex
     }
 }

--- a/Sources/Espresso/PrefillAMXShare.swift
+++ b/Sources/Espresso/PrefillAMXShare.swift
@@ -1,0 +1,210 @@
+import Accelerate
+import Foundation
+import Dispatch
+import ANEInterop
+
+/// Leftover output channels of a **batched** prefill GEMM (seq=64/256), never N=1 decode FFN.
+public enum PrefillAMXShareTarget: String, Sendable, Equatable {
+    case batchedPrefillLeftoverChannels
+}
+
+public struct ChatChunkMixTrace: Sendable, Equatable {
+    public let promptTokenCounts: [Int]
+
+    public init(promptTokenCounts: [Int]) {
+        self.promptTokenCounts = promptTokenCounts
+    }
+
+    public var medianPromptTokens: Int {
+        guard !promptTokenCounts.isEmpty else { return 0 }
+        let sorted = promptTokenCounts.sorted()
+        return sorted[sorted.count / 2]
+    }
+}
+
+public struct PrefillAMXShareDecision: Sendable, Equatable {
+    public let enabled: Bool
+    public let leftoverChannelFraction: Double
+    public let leftoverChannelCount: Int
+    public let target: PrefillAMXShareTarget
+
+    public static let off = PrefillAMXShareDecision(
+        enabled: false,
+        leftoverChannelFraction: 0,
+        leftoverChannelCount: 0,
+        target: .batchedPrefillLeftoverChannels
+    )
+}
+
+/// Hardware-local leftover share. Fractions come from ANE channel alignment remainder
+/// and the actual chat chunk mix — never omlx's 14/20/13 table.
+public struct PrefillAMXShareTuner: Sendable {
+    public let aneChannelAlignment: Int
+
+    public init(aneChannelAlignment: Int = 32) {
+        self.aneChannelAlignment = max(aneChannelAlignment, 1)
+    }
+
+    public func decide(trace: ChatChunkMixTrace, outputChannels: Int) -> PrefillAMXShareDecision {
+        guard outputChannels > 0 else { return .off }
+        let leftover = outputChannels % aneChannelAlignment
+        let decodeLike = trace.promptTokenCounts.isEmpty
+            || trace.promptTokenCounts.allSatisfy { $0 <= 4 }
+        let prefillHeavy = trace.medianPromptTokens >= 32
+        if leftover == 0 || decodeLike || !prefillHeavy {
+            return .off
+        }
+        return PrefillAMXShareDecision(
+            enabled: true,
+            leftoverChannelFraction: Double(leftover) / Double(outputChannels),
+            leftoverChannelCount: leftover,
+            target: .batchedPrefillLeftoverChannels
+        )
+    }
+}
+
+public enum BatchedPrefillGEMM {
+    /// Batched prefill GEMM. When share is on, leftover **output channels** go to
+    /// 8-shard BNNS AMX; the prefix stays on the batched GEMM (ANE stand-in).
+    public static func multiply(
+        sequenceLength: Int,
+        dim: Int,
+        outputChannels: Int,
+        input: [Float],
+        weights: [Float],
+        share: PrefillAMXShareDecision
+    ) -> [Float] {
+        precondition(QwenPrefillCompare.sequenceLengths.contains(sequenceLength))
+        precondition(dim > 0)
+        precondition(outputChannels > 0)
+        precondition(input.count == sequenceLength * dim)
+        precondition(weights.count == outputChannels * dim)
+        precondition(share.target == .batchedPrefillLeftoverChannels)
+
+        let leftover = share.enabled ? share.leftoverChannelCount : 0
+        let aneChannels = outputChannels - leftover
+        if leftover <= 0 || aneChannels <= 0 {
+            return gemm(sequenceLength: sequenceLength, dim: dim, outputChannels: outputChannels, input: input, weights: weights)
+        }
+
+        let aneWeights = Array(weights.prefix(aneChannels * dim))
+        let amxWeights = Array(weights.suffix(leftover * dim))
+        let aneOut = gemm(
+            sequenceLength: sequenceLength,
+            dim: dim,
+            outputChannels: aneChannels,
+            input: input,
+            weights: aneWeights
+        )
+        let amxOut = leftoverAMX(
+            sequenceLength: sequenceLength,
+            dim: dim,
+            leftoverChannels: leftover,
+            input: input,
+            weights: amxWeights
+        )
+
+        var stitched = [Float](repeating: 0, count: sequenceLength * outputChannels)
+        for token in 0..<sequenceLength {
+            let dst = token * outputChannels
+            let aneSrc = token * aneChannels
+            stitched.replaceSubrange(dst..<(dst + aneChannels), with: aneOut[aneSrc..<(aneSrc + aneChannels)])
+            let amxSrc = token * leftover
+            stitched.replaceSubrange(
+                (dst + aneChannels)..<(dst + outputChannels),
+                with: amxOut[amxSrc..<(amxSrc + leftover)]
+            )
+        }
+        return stitched
+    }
+
+    private static func gemm(
+        sequenceLength: Int,
+        dim: Int,
+        outputChannels: Int,
+        input: [Float],
+        weights: [Float]
+    ) -> [Float] {
+        var out = [Float](repeating: 0, count: sequenceLength * outputChannels)
+        input.withUnsafeBufferPointer { x in
+            weights.withUnsafeBufferPointer { w in
+                out.withUnsafeMutableBufferPointer { y in
+                    BLAS.sgemm(
+                        CblasRowMajor,
+                        CblasNoTrans,
+                        CblasTrans,
+                        m: Int32(sequenceLength),
+                        n: Int32(outputChannels),
+                        k: Int32(dim),
+                        alpha: 1.0,
+                        a: x.baseAddress!,
+                        lda: Int32(dim),
+                        b: w.baseAddress!,
+                        ldb: Int32(dim),
+                        beta: 0.0,
+                        c: y.baseAddress!,
+                        ldc: Int32(outputChannels)
+                    )
+                }
+            }
+        }
+        return out
+    }
+
+    private static func leftoverAMX(
+        sequenceLength: Int,
+        dim: Int,
+        leftoverChannels: Int,
+        input: [Float],
+        weights: [Float]
+    ) -> [Float] {
+        let outPtr = UnsafeMutablePointer<Float>.allocate(capacity: sequenceLength * leftoverChannels)
+        outPtr.initialize(repeating: 0, count: sequenceLength * leftoverChannels)
+        defer {
+            outPtr.deinitialize(count: sequenceLength * leftoverChannels)
+            outPtr.deallocate()
+        }
+        let shardCount = FP16TiledClassifier.eightShardCount
+        nonisolated(unsafe) let outUnsafe = outPtr
+        DispatchQueue.concurrentPerform(iterations: shardCount) { shard in
+            let range = FP16TiledClassifier.shardRowRange(
+                vocabSize: leftoverChannels,
+                shard: shard,
+                shardCount: shardCount
+            )
+            guard !range.isEmpty else { return }
+            _ = ane_interop_amx_shared_resource_hint(1, Int32(shard), 2)
+            defer { _ = ane_interop_amx_shared_resource_hint(0, Int32(shard), 2) }
+
+            let rows = range.count
+            let shardOut = UnsafeMutablePointer<Float>.allocate(capacity: sequenceLength * rows)
+            defer { shardOut.deallocate() }
+            weights.withUnsafeBufferPointer { w in
+                input.withUnsafeBufferPointer { x in
+                    BLAS.sgemm(
+                        CblasRowMajor,
+                        CblasNoTrans,
+                        CblasTrans,
+                        m: Int32(sequenceLength),
+                        n: Int32(rows),
+                        k: Int32(dim),
+                        alpha: 1.0,
+                        a: x.baseAddress!,
+                        lda: Int32(dim),
+                        b: w.baseAddress!.advanced(by: range.lowerBound * dim),
+                        ldb: Int32(dim),
+                        beta: 0.0,
+                        c: shardOut,
+                        ldc: Int32(rows)
+                    )
+                }
+            }
+            for token in 0..<sequenceLength {
+                let dst = outUnsafe.advanced(by: token * leftoverChannels + range.lowerBound)
+                let src = shardOut.advanced(by: token * rows)
+                dst.update(from: src, count: rows)
+            }
+        }
+        return Array(UnsafeBufferPointer(start: outPtr, count: sequenceLength * leftoverChannels))
+    }
+}

--- a/Sources/Espresso/QwenPrefillCompare.swift
+++ b/Sources/Espresso/QwenPrefillCompare.swift
@@ -1,0 +1,229 @@
+import Accelerate
+import Foundation
+import IOSurface
+import ANERuntime
+import ANETypes
+
+/// N=1 token loop vs one batched GEMM for Qwen prefill leftover-channel work.
+///
+/// Sequence lengths are the fixed ANE prefill shapes (64 and 256). Outputs are
+/// token-major `[seq * outputChannels]`.
+public struct QwenPrefillCompareResult: Sendable, Equatable {
+    public let sequenceLength: Int
+    public let n1Hidden: [Float]
+    public let batchedHidden: [Float]
+    public let n1WallMs: Double
+    public let batchedWallMs: Double
+    public let matchTolerance: Float
+
+    public var outputsMatch: Bool {
+        n1Hidden.count == batchedHidden.count &&
+            zip(n1Hidden, batchedHidden).allSatisfy { abs($0 - $1) <= matchTolerance }
+    }
+}
+
+public enum QwenPrefillCompare {
+    public static let sequenceLengths: [Int] = HybridDecodeKernelSet.prefillSequenceLengths
+
+    /// Compiled seq=64/256 QKV kernel (one `eval`) vs the N=1 hybrid QKV loop
+    /// (`decodeQKVOnly.eval` once per prompt token) on the same prompt IDs.
+    public static func compareHybridQKV(
+        sequenceLength: Int,
+        weights: borrowing LayerWeights
+    ) throws -> QwenPrefillCompareResult {
+        guard sequenceLengths.contains(sequenceLength) else {
+            throw ANEError.invalidArguments(
+                "Qwen prefill sequenceLength must be 64 or 256, got \(sequenceLength)"
+            )
+        }
+        let dim = weights.dim
+        let qDim = weights.qDim
+        let n1Kernels = try HybridDecodeKernelSet(weights: weights, maxSeq: sequenceLength)
+        let batchedKernels = try HybridDecodeKernelSet(
+            prefillWeights: weights,
+            sequenceLength: sequenceLength
+        )
+        let n1Handles = try HybridDecodeSurfaceHandles(
+            kernels: n1Kernels,
+            logicalMaxSeq: sequenceLength,
+            dim: dim,
+            qDim: qDim,
+            kvDim: weights.kvDim
+        )
+        let batchedHandles = try HybridDecodeSurfaceHandles(
+            kernels: batchedKernels,
+            logicalMaxSeq: sequenceLength,
+            dim: dim,
+            qDim: qDim,
+            kvDim: weights.kvDim
+        )
+
+        var tokens = [[Float]](repeating: [Float](repeating: 0, count: dim), count: sequenceLength)
+        for token in 0..<sequenceLength {
+            for channel in 0..<dim {
+                tokens[token][channel] = Float((token * 17 + channel) % 13) * 0.01
+            }
+        }
+
+        let n1Start = DispatchTime.now().uptimeNanoseconds
+        var n1Hidden = [Float](repeating: 0, count: sequenceLength * qDim)
+        for token in 0..<sequenceLength {
+            try mapSurfaceIOToANEError {
+                try tokens[token].withUnsafeBufferPointer { buf in
+                    try SurfaceIO.writeFP16SpatialSlice(
+                        to: n1Handles.qkvIn,
+                        channelOffset: 0,
+                        spatialIndex: 0,
+                        spatial: n1Handles.laneSpatial,
+                        data: buf,
+                        channels: dim
+                    )
+                }
+            }
+            try n1Kernels.decodeQKVOnly.eval()
+            try mapSurfaceIOToANEError {
+                try n1Hidden.withUnsafeMutableBufferPointer { out in
+                    let slice = UnsafeMutableBufferPointer(
+                        start: out.baseAddress!.advanced(by: token * qDim),
+                        count: qDim
+                    )
+                    try SurfaceIO.readFP16SpatialSlice(
+                        from: n1Handles.qOut,
+                        channelOffset: 0,
+                        spatialIndex: 0,
+                        spatial: n1Handles.laneSpatial,
+                        into: slice,
+                        channels: qDim
+                    )
+                }
+            }
+        }
+        let n1Ms = Double(DispatchTime.now().uptimeNanoseconds - n1Start) / 1_000_000
+
+        let batchedStart = DispatchTime.now().uptimeNanoseconds
+        for token in 0..<sequenceLength {
+            try mapSurfaceIOToANEError {
+                try tokens[token].withUnsafeBufferPointer { buf in
+                    try SurfaceIO.writeFP16SpatialSlice(
+                        to: batchedHandles.qkvIn,
+                        channelOffset: 0,
+                        spatialIndex: token,
+                        spatial: batchedHandles.laneSpatial,
+                        data: buf,
+                        channels: dim
+                    )
+                }
+            }
+        }
+        try batchedKernels.decodeQKVOnly.eval()
+        var batchedHidden = [Float](repeating: 0, count: sequenceLength * qDim)
+        for token in 0..<sequenceLength {
+            try mapSurfaceIOToANEError {
+                try batchedHidden.withUnsafeMutableBufferPointer { out in
+                    let slice = UnsafeMutableBufferPointer(
+                        start: out.baseAddress!.advanced(by: token * qDim),
+                        count: qDim
+                    )
+                    try SurfaceIO.readFP16SpatialSlice(
+                        from: batchedHandles.qOut,
+                        channelOffset: 0,
+                        spatialIndex: token,
+                        spatial: batchedHandles.laneSpatial,
+                        into: slice,
+                        channels: qDim
+                    )
+                }
+            }
+        }
+        let batchedMs = Double(DispatchTime.now().uptimeNanoseconds - batchedStart) / 1_000_000
+
+        return QwenPrefillCompareResult(
+            sequenceLength: sequenceLength,
+            n1Hidden: n1Hidden,
+            batchedHidden: batchedHidden,
+            n1WallMs: n1Ms,
+            batchedWallMs: batchedMs,
+            matchTolerance: 2e-2
+        )
+    }
+
+    /// Sequential N=1 GEMVs vs one GEMM on the same prompt IDs / weights.
+    public static func compareCPUMatmul(
+        sequenceLength: Int,
+        dim: Int,
+        outputChannels: Int,
+        input: [Float],
+        weights: [Float]
+    ) -> QwenPrefillCompareResult {
+        precondition(sequenceLengths.contains(sequenceLength))
+        precondition(dim > 0)
+        precondition(outputChannels > 0)
+        precondition(input.count == sequenceLength * dim)
+        precondition(weights.count == outputChannels * dim)
+
+        let n1Start = DispatchTime.now().uptimeNanoseconds
+        var n1 = [Float](repeating: 0, count: sequenceLength * outputChannels)
+        input.withUnsafeBufferPointer { x in
+            weights.withUnsafeBufferPointer { w in
+                n1.withUnsafeMutableBufferPointer { y in
+                    for token in 0..<sequenceLength {
+                        let xTok = x.baseAddress!.advanced(by: token * dim)
+                        let yTok = y.baseAddress!.advanced(by: token * outputChannels)
+                        BLAS.sgemm(
+                            CblasRowMajor,
+                            CblasNoTrans,
+                            CblasTrans,
+                            m: 1,
+                            n: Int32(outputChannels),
+                            k: Int32(dim),
+                            alpha: 1.0,
+                            a: xTok,
+                            lda: Int32(dim),
+                            b: w.baseAddress!,
+                            ldb: Int32(dim),
+                            beta: 0.0,
+                            c: yTok,
+                            ldc: Int32(outputChannels)
+                        )
+                    }
+                }
+            }
+        }
+        let n1Ms = Double(DispatchTime.now().uptimeNanoseconds - n1Start) / 1_000_000
+
+        let batchedStart = DispatchTime.now().uptimeNanoseconds
+        var batched = [Float](repeating: 0, count: sequenceLength * outputChannels)
+        input.withUnsafeBufferPointer { x in
+            weights.withUnsafeBufferPointer { w in
+                batched.withUnsafeMutableBufferPointer { y in
+                    BLAS.sgemm(
+                        CblasRowMajor,
+                        CblasNoTrans,
+                        CblasTrans,
+                        m: Int32(sequenceLength),
+                        n: Int32(outputChannels),
+                        k: Int32(dim),
+                        alpha: 1.0,
+                        a: x.baseAddress!,
+                        lda: Int32(dim),
+                        b: w.baseAddress!,
+                        ldb: Int32(dim),
+                        beta: 0.0,
+                        c: y.baseAddress!,
+                        ldc: Int32(outputChannels)
+                    )
+                }
+            }
+        }
+        let batchedMs = Double(DispatchTime.now().uptimeNanoseconds - batchedStart) / 1_000_000
+
+        return QwenPrefillCompareResult(
+            sequenceLength: sequenceLength,
+            n1Hidden: n1,
+            batchedHidden: batched,
+            n1WallMs: n1Ms,
+            batchedWallMs: batchedMs,
+            matchTolerance: 1e-4
+        )
+    }
+}

--- a/Sources/EspressoGenerate/CLI.swift
+++ b/Sources/EspressoGenerate/CLI.swift
@@ -502,6 +502,7 @@ struct BackendRunMetrics: Sendable {
     let promptTokens: [TokenID]
     let compileTimeMs: Double
     let firstTokenLatencyMs: Double
+    let prefillMs: Double
     let tokensPerSecond: Double
     let medianTokenMs: Double
     let p95TokenMs: Double
@@ -525,6 +526,7 @@ struct BackendRunMetrics: Sendable {
         promptTokens: [TokenID],
         compileTimeMs: Double,
         firstTokenLatencyMs: Double,
+        prefillMs: Double = 0,
         tokensPerSecond: Double,
         medianTokenMs: Double,
         p95TokenMs: Double,
@@ -547,6 +549,7 @@ struct BackendRunMetrics: Sendable {
         self.promptTokens = promptTokens
         self.compileTimeMs = compileTimeMs
         self.firstTokenLatencyMs = firstTokenLatencyMs
+        self.prefillMs = prefillMs
         self.tokensPerSecond = tokensPerSecond
         self.medianTokenMs = medianTokenMs
         self.p95TokenMs = p95TokenMs
@@ -1351,6 +1354,7 @@ private func makeBundleRuntimeMetrics(bundle: ESPRuntimeBundle, invocation: Reso
         promptTokens: result.promptTokens,
         compileTimeMs: result.compileTimeMs,
         firstTokenLatencyMs: result.firstTokenLatencyMs,
+        prefillMs: result.prefillMs,
         tokensPerSecond: result.tokensPerSecond,
         medianTokenMs: percentile(tokenLatenciesMs, percentile: 0.5),
         p95TokenMs: percentile(tokenLatenciesMs, percentile: 0.95),
@@ -1437,6 +1441,7 @@ private func runEspressoGeneration(
         promptTokens: result.promptTokens,
         compileTimeMs: result.compileTimeMs,
         firstTokenLatencyMs: result.firstTokenLatencyMs,
+        prefillMs: result.prefillMs,
         tokensPerSecond: result.tokensPerSecond,
         medianTokenMs: percentile(tokenLatenciesMs, percentile: 0.5),
         p95TokenMs: percentile(tokenLatenciesMs, percentile: 0.95),
@@ -1508,6 +1513,7 @@ func aggregateBenchmarkRuns(
         promptTokens: lastMeasured.promptTokens,
         compileTimeMs: compileTimeMs,
         firstTokenLatencyMs: lastMeasured.firstTokenLatencyMs,
+        prefillMs: lastMeasured.prefillMs,
         tokensPerSecond: lastMeasured.tokensPerSecond,
         medianTokenMs: percentile(aggregatedLatencySamples, percentile: 0.5),
         p95TokenMs: percentile(aggregatedLatencySamples, percentile: 0.95),
@@ -1676,7 +1682,7 @@ private func compareReport(
 private func printGenerateStats(_ invocation: ResolvedInvocation, result: BackendRunMetrics) {
     stderrLine(
         String(
-            format: "model=%@ prompt_tokens=%d generated_tokens=%d compile_ms=%.2f compile_retries=%d compile_failures=%d first_token_ms=%.2f tok_per_s=%.2f median_token_ms=%.2f p95_token_ms=%.2f",
+            format: "model=%@ prompt_tokens=%d generated_tokens=%d compile_ms=%.2f compile_retries=%d compile_failures=%d prefill_ms=%.2f first_token_ms=%.2f tok_per_s=%.2f median_token_ms=%.2f p95_token_ms=%.2f",
             locale: posixLocale,
             invocation.config.name,
             result.promptTokens.count,
@@ -1684,6 +1690,7 @@ private func printGenerateStats(_ invocation: ResolvedInvocation, result: Backen
             result.compileTimeMs,
             result.compileRetryCount,
             result.compileFailureCount,
+            result.prefillMs,
             result.firstTokenLatencyMs,
             result.tokensPerSecond,
             result.medianTokenMs,
@@ -1923,13 +1930,24 @@ private func writeGenerateArtifacts(
     return outputDir.path
 }
 
+func generateTimingJSONFields(from metrics: BackendRunMetrics) -> [String: Double] {
+    [
+        "prefill_ms": metrics.prefillMs,
+        "first_token_latency_ms": metrics.firstTokenLatencyMs,
+        "ttft_including_prefill_ms": metrics.firstTokenLatencyMs,
+    ]
+}
+
 private func backendPayload(_ backend: BackendRunMetrics) -> [String: Any] {
     let fingerprint = benchmarkFingerprint(for: backend)
+    let timing = generateTimingJSONFields(from: backend)
     return [
         "compile_time_ms": backend.compileTimeMs,
         "compile_retry_count": backend.compileRetryCount,
         "compile_failure_count": backend.compileFailureCount,
-        "first_token_latency_ms": backend.firstTokenLatencyMs,
+        "prefill_ms": timing["prefill_ms"] as Any,
+        "first_token_latency_ms": timing["first_token_latency_ms"] as Any,
+        "ttft_including_prefill_ms": timing["ttft_including_prefill_ms"] as Any,
         "tokens_per_second": backend.tokensPerSecond,
         "median_token_ms": backend.medianTokenMs,
         "p95_token_ms": backend.p95TokenMs,
@@ -3488,7 +3506,11 @@ private func runChat(invocation: ResolvedInvocation, options: Options, powerEnab
                                 cancel.requestCancel()
                             }
                             footer.tokensPerSecond = step.tokensPerSecond
-                            footer.ttftMs = step.firstTokenLatencyMs
+                            applyPublishedGenerateTiming(
+                                prefillMs: step.prefillMs,
+                                ttftIncludingPrefillMs: step.firstTokenLatencyMs,
+                                to: &footer
+                            )
                             footer.contextUsed = promptTokenCount + step.generatedTokens.count
                             if useTUI {
                                 renderTUI(status: .generating)
@@ -3504,7 +3526,11 @@ private func runChat(invocation: ResolvedInvocation, options: Options, powerEnab
                 try assertChatDecodePathIsHybrid(result.decodePath)
                 footer.decodePath = result.decodePath
                 footer.tokensPerSecond = result.tokensPerSecond
-                footer.ttftMs = result.firstTokenLatencyMs
+                applyPublishedGenerateTiming(
+                    prefillMs: result.prefillMs,
+                    ttftIncludingPrefillMs: result.firstTokenLatencyMs,
+                    to: &footer
+                )
                 footer.contextUsed = result.promptTokens.count + result.tokens.count
                 footer.power = chatPowerFooter(
                     capability: powerCapability,

--- a/Sources/EspressoGenerate/ChatTUI.swift
+++ b/Sources/EspressoGenerate/ChatTUI.swift
@@ -54,6 +54,16 @@ func chatPowerFooter(
     )
 }
 
+/// Published chat TTFT is submit→first token including prefill, not LM-head-only.
+func applyPublishedGenerateTiming(
+    prefillMs: Double,
+    ttftIncludingPrefillMs: Double,
+    to footer: inout ChatStatusFooter
+) {
+    footer.prefillMs = prefillMs
+    footer.ttftMs = max(ttftIncludingPrefillMs, prefillMs)
+}
+
 func chatPowerUnavailableMessage(_ capability: PowerCapability) -> String {
     let message = capability.message.trimmingCharacters(in: .whitespacesAndNewlines)
     let lowered = message.lowercased()
@@ -69,6 +79,7 @@ func chatPowerUnavailableMessage(_ capability: PowerCapability) -> String {
 struct ChatStatusFooter: Equatable, Sendable {
     var tokensPerSecond: Double
     var ttftMs: Double
+    var prefillMs: Double = 0
     var decodePath: String
     var contextUsed: Int
     var contextMax: Int
@@ -77,7 +88,8 @@ struct ChatStatusFooter: Equatable, Sendable {
     func render() -> String {
         let tok = tokensPerSecond.isFinite ? String(format: "%.1f", tokensPerSecond) : "—"
         let ttft = ttftMs.isFinite ? String(format: "%.0f", ttftMs) : "—"
-        let metrics = "tok/s \(tok)  TTFT \(ttft)ms  path=\(decodePath)  ctx \(contextUsed)/\(contextMax)"
+        let prefill = prefillMs.isFinite ? String(format: "%.0f", prefillMs) : "—"
+        let metrics = "tok/s \(tok)  TTFT \(ttft)ms  prefill \(prefill)ms  path=\(decodePath)  ctx \(contextUsed)/\(contextMax)"
         return metrics + "\n" + power.render()
     }
 

--- a/Sources/RealModelInference/EmissionCore.swift
+++ b/Sources/RealModelInference/EmissionCore.swift
@@ -34,7 +34,9 @@ struct EmissionCore {
     private let startNanos: UInt64
     /// Clock of the previous emission (initialized to session start).
     private var lastEmissionNanos: UInt64
+    private var clock: GenerateClock
     private var firstTokenLatencyMsValue = 0.0
+    private var prefillMsValue = 0.0
     private var firstTokenRecorded = false
 
     /// Prompt plus every fully emitted token; the text carrier.
@@ -53,14 +55,17 @@ struct EmissionCore {
         eos: EOSPolicy,
         onStep: ((GenerationStep) -> Void)?,
         decodeText: @escaping ([Int]) -> String,
-        startNanos: UInt64 = DispatchTime.now().uptimeNanoseconds
+        startNanos: UInt64 = DispatchTime.now().uptimeNanoseconds,
+        clock: GenerateClock? = nil
     ) {
         self.eosTokenID = switch eos {
         case .fixed(let tokenID): tokenID
         case .fromConfig(let tokenID): tokenID
         }
-        self.startNanos = startNanos
-        self.lastEmissionNanos = startNanos
+        let resolvedClock = clock ?? GenerateClock(submitNS: startNanos)
+        self.clock = resolvedClock
+        self.startNanos = resolvedClock.submitNS
+        self.lastEmissionNanos = resolvedClock.submitNS
         self.allTokens = promptTokens
         self.generatedTokens = []
         self.generatedTokens.reserveCapacity(capacity)
@@ -95,7 +100,10 @@ struct EmissionCore {
     /// closure-style loops whose only capture point is the emit itself.
     mutating func recordFirstTokenIfFirst(at now: UInt64) {
         guard !firstTokenRecorded else { return }
-        firstTokenLatencyMsValue = Self.milliseconds(from: now - startNanos)
+        clock.markPrefillEnd(at: now)
+        let timing = clock.timing(firstTokenNS: now)
+        firstTokenLatencyMsValue = timing.firstTokenLatencyMs
+        prefillMsValue = timing.prefillMs
         firstTokenRecorded = true
     }
 
@@ -123,6 +131,7 @@ struct EmissionCore {
                 tokenLatencyMs: tokenLatencyMs,
                 elapsedMs: elapsedMs,
                 firstTokenLatencyMs: firstTokenLatencyMsValue,
+                prefillMs: prefillMsValue,
                 tokensPerSecond: tokensPerSecond
             )
         )
@@ -161,6 +170,7 @@ struct EmissionCore {
             ),
             compileTimeMs: compileTimeMs,
             firstTokenLatencyMs: firstTokenLatencyMsValue,
+            prefillMs: prefillMsValue,
             exactHeadBackend: exactHeadBackend ?? "unknown",
             cachedBindingsEnabled: cachedBindingsEnabled,
             committedExactTokensPerPass: committedExactTokensPerPass,

--- a/Sources/RealModelInference/GenerateTiming.swift
+++ b/Sources/RealModelInference/GenerateTiming.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Prefill + first-token wall times for generate/chat.
+///
+/// `firstTokenLatencyMs` is TTFT including prefill: prompt-submit through the
+/// first emitted token. Compile time is not included. Decode tok/s keeps a
+/// separate post-prefill clock.
+public struct GenerateTiming: Sendable, Equatable {
+    public let prefillMs: Double
+    public let firstTokenLatencyMs: Double
+
+    public var ttftIncludingPrefillMs: Double { firstTokenLatencyMs }
+
+    public init(prefillMs: Double, firstTokenLatencyIncludingPrefillMs: Double) {
+        self.prefillMs = prefillMs
+        self.firstTokenLatencyMs = max(firstTokenLatencyIncludingPrefillMs, prefillMs)
+    }
+
+    public static func milliseconds(from nanoseconds: UInt64) -> Double {
+        Double(nanoseconds) / 1_000_000
+    }
+}
+
+/// Wall clock from prompt submit, with an explicit prefill-end mark.
+public struct GenerateClock: Sendable {
+    public let submitNS: UInt64
+    public private(set) var prefillEndNS: UInt64
+    private let now: @Sendable () -> UInt64
+
+    public init(now: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }) {
+        self.now = now
+        let t = now()
+        self.submitNS = t
+        self.prefillEndNS = t
+    }
+
+    public init(submitNS: UInt64, now: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }) {
+        self.now = now
+        self.submitNS = submitNS
+        self.prefillEndNS = submitNS
+    }
+
+    public var decodeStartNS: UInt64 { prefillEndNS }
+
+    public mutating func markPrefillEnd() {
+        markPrefillEnd(at: now())
+    }
+
+    public mutating func markPrefillEnd(at ns: UInt64) {
+        prefillEndNS = ns
+    }
+
+    public func prefillMs() -> Double {
+        GenerateTiming.milliseconds(from: prefillEndNS - submitNS)
+    }
+
+    public func ttftIncludingPrefillMs(at emissionNS: UInt64) -> Double {
+        let ttft = GenerateTiming.milliseconds(from: emissionNS - submitNS)
+        return max(ttft, prefillMs())
+    }
+
+    public func timing(firstTokenNS: UInt64) -> GenerateTiming {
+        GenerateTiming(
+            prefillMs: prefillMs(),
+            firstTokenLatencyIncludingPrefillMs: ttftIncludingPrefillMs(at: firstTokenNS)
+        )
+    }
+}

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -21,7 +21,10 @@ public struct GenerationResult: Sendable {
     public let tokenLatenciesMs: [Double]
     public let tokensPerSecond: Double
     public let compileTimeMs: Double
+    /// Wall from prompt submit through the first emitted token, **including prefill**.
     public let firstTokenLatencyMs: Double
+    /// Wall of the prefill phase only (submit → last prefill step). Compile is excluded.
+    public let prefillMs: Double
     public let exactHeadBackend: String
     public let cachedBindingsEnabled: Bool
     public let committedExactTokensPerPass: Double?
@@ -39,6 +42,9 @@ public struct GenerationResult: Sendable {
         trunk?.telemetryLabel ?? "unknown"
     }
 
+    /// Published TTFT: submit through first token, including prefill.
+    public var ttftIncludingPrefillMs: Double { firstTokenLatencyMs }
+
     public init(
         text: String,
         tokens: [TokenID],
@@ -47,6 +53,7 @@ public struct GenerationResult: Sendable {
         tokensPerSecond: Double,
         compileTimeMs: Double,
         firstTokenLatencyMs: Double,
+        prefillMs: Double = 0,
         exactHeadBackend: String = "unknown",
         cachedBindingsEnabled: Bool = false,
         committedExactTokensPerPass: Double? = nil,
@@ -62,6 +69,7 @@ public struct GenerationResult: Sendable {
         self.tokensPerSecond = tokensPerSecond
         self.compileTimeMs = compileTimeMs
         self.firstTokenLatencyMs = firstTokenLatencyMs
+        self.prefillMs = prefillMs
         self.exactHeadBackend = exactHeadBackend
         self.cachedBindingsEnabled = cachedBindingsEnabled
         self.committedExactTokensPerPass = committedExactTokensPerPass
@@ -124,6 +132,7 @@ public struct GenerationResult: Sendable {
             tokensPerSecond: tokensPerSecond,
             compileTimeMs: compileTimeMs,
             firstTokenLatencyMs: firstTokenLatencyMs,
+            prefillMs: prefillMs,
             exactHeadBackend: exactHeadBackend,
             cachedBindingsEnabled: cachedBindingsEnabled,
             committedExactTokensPerPass: committedExactTokensPerPass,
@@ -152,6 +161,7 @@ public struct GenerationStep: Sendable {
     public let tokenLatencyMs: Double
     public let elapsedMs: Double
     public let firstTokenLatencyMs: Double
+    public let prefillMs: Double
     public let tokensPerSecond: Double
 
     public init(
@@ -161,6 +171,7 @@ public struct GenerationStep: Sendable {
         tokenLatencyMs: Double,
         elapsedMs: Double,
         firstTokenLatencyMs: Double,
+        prefillMs: Double = 0,
         tokensPerSecond: Double
     ) {
         self.token = token
@@ -169,6 +180,7 @@ public struct GenerationStep: Sendable {
         self.tokenLatencyMs = tokenLatencyMs
         self.elapsedMs = elapsedMs
         self.firstTokenLatencyMs = firstTokenLatencyMs
+        self.prefillMs = prefillMs
         self.tokensPerSecond = tokensPerSecond
     }
 }
@@ -4973,8 +4985,12 @@ public struct RealModelInferenceEngine: ~Copyable {
         var fullRuntime = try CPUExactLlamaRuntime(config: config, weightDirURL: weightDirURL)
         var draftRuntime = try CPUExactLlamaRuntime(config: draft.config, weightDirURL: draft.weightDirURL)
 
+        var clock = GenerateClock()
         try fullRuntime.prefill(promptTokens: promptTokens)
         try draftRuntime.prefill(promptTokens: promptTokens)
+        clock.markPrefillEnd()
+        let prefillMs = clock.prefillMs()
+        let submitNS = clock.submitNS
 
         let generationStart = DispatchTime.now().uptimeNanoseconds
         let tokenizer = self.tokenizer

--- a/Tests/ANERuntimeTests/ANEEvalTimingTests.swift
+++ b/Tests/ANERuntimeTests/ANEEvalTimingTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import ANERuntime
+
+final class ANEEvalTimingTests: XCTestCase {
+    func test_recorder_stores_wall_and_hw_from_shipped_record_call() {
+        let recorder = ANEEvalTimingRecorder()
+        recorder.record(wallNanoseconds: 5_000, hardwareNanoseconds: 3_000)
+        XCTAssertEqual(recorder.lastWallNanoseconds, 5_000)
+        XCTAssertEqual(recorder.lastWallMicroseconds, 5.0, accuracy: 1e-9)
+        XCTAssertEqual(recorder.lastHWExecutionTimeNS, 3_000)
+        XCTAssertGreaterThanOrEqual(recorder.lastWallNanoseconds, recorder.lastHWExecutionTimeNS)
+    }
+
+    func test_recorder_allows_zero_hw_when_perf_stats_off() {
+        let recorder = ANEEvalTimingRecorder()
+        recorder.record(wallNanoseconds: 2_000, hardwareNanoseconds: 0)
+        XCTAssertEqual(recorder.lastWallMicroseconds, 2.0, accuracy: 1e-9)
+        XCTAssertEqual(recorder.lastHWExecutionTimeNS, 0)
+    }
+}

--- a/Tests/ANERuntimeTests/HybridDecodeKernelSetTests.swift
+++ b/Tests/ANERuntimeTests/HybridDecodeKernelSetTests.swift
@@ -76,6 +76,61 @@ final class HybridDecodeKernelSetTests: XCTestCase {
         XCTAssertTrue(specs[2].milText.contains("w2.bin"))
     }
 
+    func test_prefill_compile_specs_exist_for_seq64_and_seq256() {
+        let weights = makeHybridTestLayerWeights()
+        XCTAssertEqual(HybridDecodeKernelSet.prefillSequenceLengths, [64, 256])
+        for seq in HybridDecodeKernelSet.prefillSequenceLengths {
+            let specs = HybridDecodeKernelSet.prefillCompileSpecs(weights: weights, sequenceLength: seq)
+            XCTAssertEqual(specs.count, 3)
+            XCTAssertEqual(specs[0].kind, .decodeQKVOnly)
+            XCTAssertEqual(specs[1].kind, .decodeProjection)
+            XCTAssertEqual(specs[2].kind, .decodeFFN)
+            XCTAssertEqual(specs[0].inputSizes, [ModelConfig.dim * seq * 2])
+            XCTAssertEqual(specs[2].inputSizes, [ModelConfig.dim * seq * 2])
+        }
+    }
+
+    func test_prefill_kernel_compile_seq64_when_ane_available() throws {
+        try requireHybridANEHardware()
+        let weights = makeHybridTestLayerWeights()
+        let kernels = try HybridDecodeKernelSet(prefillWeights: weights, sequenceLength: 64)
+        XCTAssertEqual(kernels.laneSpatial, 64)
+        XCTAssertEqual(kernels.maxSeq, 64)
+    }
+
+    func test_prefill_qkv_eval_records_wall_next_to_lastHWExecutionTimeNS() throws {
+        try requireHybridANEHardware()
+        let weights = makeHybridTestLayerWeights()
+        let kernels = try HybridDecodeKernelSet(prefillWeights: weights, sequenceLength: 64)
+        do {
+            try kernels.decodeQKVOnly.eval()
+        } catch {
+            throw XCTSkip("ANE QKV eval unavailable: \(error)")
+        }
+        print(
+            "eval_timing wall_us=\(kernels.decodeQKVOnly.lastEvalWallMicroseconds) hw_ns=\(kernels.decodeQKVOnly.lastEvalHWExecutionTimeNS) lastHW=\(kernels.decodeQKVOnly.lastHWExecutionTimeNS())"
+        )
+        XCTAssertGreaterThan(kernels.decodeQKVOnly.lastEvalWallMicroseconds, 0)
+        XCTAssertEqual(
+            kernels.decodeQKVOnly.lastEvalHWExecutionTimeNS,
+            kernels.decodeQKVOnly.lastHWExecutionTimeNS()
+        )
+        if kernels.decodeQKVOnly.lastEvalHWExecutionTimeNS > 0 {
+            XCTAssertGreaterThanOrEqual(
+                kernels.decodeQKVOnly.lastEvalWallNanoseconds,
+                kernels.decodeQKVOnly.lastEvalHWExecutionTimeNS
+            )
+        }
+    }
+
+    func test_prefill_kernel_compile_seq256_when_ane_available() throws {
+        try requireHybridANEHardware()
+        let weights = makeHybridTestLayerWeights()
+        let kernels = try HybridDecodeKernelSet(prefillWeights: weights, sequenceLength: 256)
+        XCTAssertEqual(kernels.laneSpatial, 256)
+        XCTAssertEqual(kernels.maxSeq, 256)
+    }
+
     func test_compile_specs_include_gpt2_layernorm_and_bias_weights() {
         let weights = makeHybridTestLayerWeights().withArchitecture(.gpt2)
         let specs = HybridDecodeKernelSet.compileSpecs(weights: weights, maxSeq: 17)

--- a/Tests/ANERuntimeTests/RealTimeEvalProbeTests.swift
+++ b/Tests/ANERuntimeTests/RealTimeEvalProbeTests.swift
@@ -83,6 +83,21 @@ final class RealTimeEvalProbeTests: XCTestCase {
 
     // MARK: - Hardware-gated tests
 
+    func test_eval_records_wall_next_to_lastHWExecutionTimeNS() throws {
+        try requireANEHardwareTests()
+        let kernel = try identityKernel()
+        do {
+            try kernel.eval()
+        } catch {
+            throw XCTSkip("ANE eval unavailable for identity kernel: \(error)")
+        }
+        XCTAssertGreaterThan(kernel.lastEvalWallMicroseconds, 0)
+        XCTAssertEqual(kernel.lastEvalHWExecutionTimeNS, kernel.lastHWExecutionTimeNS())
+        if kernel.lastEvalHWExecutionTimeNS > 0 {
+            XCTAssertGreaterThanOrEqual(kernel.lastEvalWallNanoseconds, kernel.lastEvalHWExecutionTimeNS)
+        }
+    }
+
     func test_realtime_selector_discovery() throws {
         try requireANEHardwareTests()
         let kernel = try identityKernel()

--- a/Tests/EspressoGenerateTests/EspressoGenerateTests.swift
+++ b/Tests/EspressoGenerateTests/EspressoGenerateTests.swift
@@ -1367,6 +1367,46 @@ private func makeStubDemoDefaults(root: URL) -> DemoDefaults {
     #expect(!rendered.contains("J/tok"))
 }
 
+@Test func test_chatFooterPublishedTTFTIncludesPrefillNotHeadOnly() {
+    var footer = ChatStatusFooter(
+        tokensPerSecond: 2.1,
+        ttftMs: 21,
+        decodePath: "hybrid",
+        contextUsed: 64,
+        contextMax: 1024
+    )
+    applyPublishedGenerateTiming(prefillMs: 80, ttftIncludingPrefillMs: 101, to: &footer)
+    #expect(footer.prefillMs == 80)
+    #expect(footer.ttftMs == 101)
+    #expect(footer.ttftMs >= footer.prefillMs)
+    #expect(footer.ttftMs != 21)
+    let rendered = footer.render()
+    #expect(rendered.contains("TTFT 101ms"))
+    #expect(rendered.contains("prefill 80ms"))
+}
+
+@Test func test_generateJSONTimingFieldsPublishIncludingPrefillTTFT() {
+    let metrics = BackendRunMetrics(
+        backend: "espresso",
+        text: "hi",
+        generatedTokens: [1],
+        promptTokens: [9, 8, 7, 6],
+        compileTimeMs: 10,
+        firstTokenLatencyMs: 101,
+        prefillMs: 80,
+        tokensPerSecond: 2,
+        medianTokenMs: 21,
+        p95TokenMs: 21,
+        totalTimeMs: 200,
+        tokenLatenciesMs: [21]
+    )
+    let fields = generateTimingJSONFields(from: metrics)
+    #expect(fields["prefill_ms"] == 80)
+    #expect(fields["ttft_including_prefill_ms"] == 101)
+    #expect(fields["first_token_latency_ms"] == fields["ttft_including_prefill_ms"])
+    #expect(fields["first_token_latency_ms"]! >= fields["prefill_ms"]!)
+}
+
 @Test func test_joulesPerTokenIsPackageWattsDividedByTokensPerSecond() {
     #expect(joulesPerToken(packageWatts: 3.25, tokensPerSecond: 13) == 0.25)
     #expect(joulesPerToken(packageWatts: 4, tokensPerSecond: 8) == 0.5)

--- a/Tests/EspressoTests/FP16TiledClassifierTests.swift
+++ b/Tests/EspressoTests/FP16TiledClassifierTests.swift
@@ -196,4 +196,73 @@ final class FP16TiledClassifierTests: XCTestCase {
         XCTAssertEqual(streaming, tiled)
         XCTAssertEqual(streaming, 137)
     }
+
+    func testBNNSEightShardArgmaxMatchesTiledAndStreamingIncludingFirstMaxTie() {
+        XCTAssertEqual(FP16TiledClassifier.eightShardCount, 8)
+
+        func run(vocabSize: Int, dim: Int, dominantRow: Int?, tieRows: (Int, Int)?) {
+            let classifierFP32 = TensorBuffer(count: vocabSize * dim, zeroed: true)
+            let input = UnsafeMutablePointer<Float>.allocate(capacity: dim)
+            defer { input.deallocate() }
+            for i in 0..<dim { input[i] = 1.0 }
+            classifierFP32.withUnsafeMutablePointer { ptr in
+                for r in 0..<vocabSize {
+                    for c in 0..<dim {
+                        ptr[r * dim + c] = Float(r) * 0.01 + Float(c) * 0.001
+                    }
+                }
+                if let dominantRow {
+                    for c in 0..<dim {
+                        ptr[dominantRow * dim + c] = 10.0
+                    }
+                }
+                if let tieRows {
+                    for c in 0..<dim {
+                        ptr[tieRows.0 * dim + c] = 7.0
+                        ptr[tieRows.1 * dim + c] = 7.0
+                    }
+                }
+            }
+            let fp16Weights = TensorBufferFP16(quantizing: classifierFP32, rows: vocabSize, cols: dim)
+            let tiled = fp16Weights.withUnsafePointer { fp16Ptr in
+                FP16TiledClassifier.tiledMatvecArgmax(
+                    weights: fp16Ptr,
+                    input: UnsafePointer(input),
+                    vocabSize: vocabSize,
+                    dim: dim,
+                    tileRows: 7
+                )
+            }
+            let streaming = fp16Weights.withUnsafePointer { fp16Ptr in
+                FP16TiledClassifier.streamingMatvecArgmax(
+                    weights: fp16Ptr,
+                    input: UnsafePointer(input),
+                    vocabSize: vocabSize,
+                    dim: dim
+                )
+            }
+            let bnns = fp16Weights.withUnsafePointer { fp16Ptr in
+                FP16TiledClassifier.bnnsEightShardMatvecArgmax(
+                    weights: fp16Ptr,
+                    input: UnsafePointer(input),
+                    vocabSize: vocabSize,
+                    dim: dim
+                )
+            }
+            print(
+                "bnns_8shard shards=\(FP16TiledClassifier.eightShardCount) vocab=\(vocabSize) dim=\(dim) tiled=\(tiled) streaming=\(streaming) bnns=\(bnns) dominant=\(String(describing: dominantRow)) tie=\(String(describing: tieRows))"
+            )
+            XCTAssertEqual(bnns, tiled)
+            XCTAssertEqual(bnns, streaming)
+            if let dominantRow {
+                XCTAssertEqual(bnns, dominantRow)
+            }
+            if let tieRows {
+                XCTAssertEqual(bnns, min(tieRows.0, tieRows.1))
+            }
+        }
+
+        run(vocabSize: 24, dim: 16, dominantRow: 19, tieRows: nil)
+        run(vocabSize: 24, dim: 16, dominantRow: nil, tieRows: (3, 20))
+    }
 }

--- a/Tests/EspressoTests/PrefillAMXShareTests.swift
+++ b/Tests/EspressoTests/PrefillAMXShareTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import Espresso
+
+final class PrefillAMXShareTests: XCTestCase {
+    func test_tuner_does_not_copy_omlx_split_table_and_targets_batched_prefill() {
+        let tuner = PrefillAMXShareTuner(aneChannelAlignment: 32)
+        let decodeTrace = ChatChunkMixTrace(promptTokenCounts: [1, 2, 1, 3])
+        let decodeDecision = tuner.decide(trace: decodeTrace, outputChannels: 100)
+        print(
+            "tuner_input decode_chunks=\(decodeTrace.promptTokenCounts) output_channels=100 median=\(decodeTrace.medianPromptTokens) decision_enabled=\(decodeDecision.enabled) leftover_frac=\(decodeDecision.leftoverChannelFraction) leftover_count=\(decodeDecision.leftoverChannelCount) target=\(decodeDecision.target)"
+        )
+        XCTAssertFalse(decodeDecision.enabled)
+        XCTAssertEqual(decodeDecision.target, .batchedPrefillLeftoverChannels)
+        XCTAssertNotEqual(decodeDecision.leftoverChannelFraction, 0.14)
+        XCTAssertNotEqual(decodeDecision.leftoverChannelFraction, 0.20)
+        XCTAssertNotEqual(decodeDecision.leftoverChannelFraction, 0.13)
+
+        let chatTrace = ChatChunkMixTrace(promptTokenCounts: [51, 77, 138, 202, 256])
+        let on = tuner.decide(trace: chatTrace, outputChannels: 100)
+        print(
+            "tuner_input chat_chunks=\(chatTrace.promptTokenCounts) output_channels=100 median=\(chatTrace.medianPromptTokens) decision_enabled=\(on.enabled) leftover_frac=\(on.leftoverChannelFraction) leftover_count=\(on.leftoverChannelCount) target=\(on.target)"
+        )
+        XCTAssertTrue(on.enabled)
+        XCTAssertEqual(on.leftoverChannelCount, 4)
+        XCTAssertEqual(on.target, .batchedPrefillLeftoverChannels)
+        XCTAssertEqual(on.leftoverChannelFraction, 0.04, accuracy: 1e-12)
+        XCTAssertNotEqual(on.leftoverChannelFraction, 0.14)
+        XCTAssertNotEqual(on.leftoverChannelFraction, 0.20)
+        XCTAssertNotEqual(on.leftoverChannelFraction, 0.13)
+
+        let aligned = tuner.decide(trace: chatTrace, outputChannels: 96)
+        print(
+            "tuner_input aligned_chunks=\(chatTrace.promptTokenCounts) output_channels=96 decision_enabled=\(aligned.enabled) leftover_frac=\(aligned.leftoverChannelFraction) leftover_count=\(aligned.leftoverChannelCount) target=\(aligned.target)"
+        )
+        XCTAssertFalse(aligned.enabled)
+    }
+
+    func test_leftover_share_applies_to_batched_prefill_gemm_not_n1() {
+        let seq = 64
+        let dim = 8
+        let out = 12
+        var input = [Float](repeating: 0, count: seq * dim)
+        var weights = [Float](repeating: 0, count: out * dim)
+        for i in input.indices { input[i] = Float(i % 5) * 0.2 }
+        for i in weights.indices { weights[i] = Float((i * 2) % 9) * 0.1 }
+
+        let baseline = QwenPrefillCompare.compareCPUMatmul(
+            sequenceLength: seq,
+            dim: dim,
+            outputChannels: out,
+            input: input,
+            weights: weights
+        )
+        let off = BatchedPrefillGEMM.multiply(
+            sequenceLength: seq,
+            dim: dim,
+            outputChannels: out,
+            input: input,
+            weights: weights,
+            share: .off
+        )
+        XCTAssertEqual(off.count, baseline.batchedHidden.count)
+        for (lhs, rhs) in zip(off, baseline.batchedHidden) {
+            XCTAssertEqual(lhs, rhs, accuracy: 1e-4)
+        }
+
+        let share = PrefillAMXShareDecision(
+            enabled: true,
+            leftoverChannelFraction: 4.0 / 12.0,
+            leftoverChannelCount: 4,
+            target: .batchedPrefillLeftoverChannels
+        )
+        XCTAssertEqual(share.target, .batchedPrefillLeftoverChannels)
+        let split = BatchedPrefillGEMM.multiply(
+            sequenceLength: seq,
+            dim: dim,
+            outputChannels: out,
+            input: input,
+            weights: weights,
+            share: share
+        )
+        XCTAssertEqual(split.count, baseline.batchedHidden.count)
+        for (lhs, rhs) in zip(split, baseline.batchedHidden) {
+            XCTAssertEqual(lhs, rhs, accuracy: 1e-3)
+        }
+    }
+}

--- a/Tests/EspressoTests/QwenPrefillCompareTests.swift
+++ b/Tests/EspressoTests/QwenPrefillCompareTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import ANETypes
+import ANERuntime
+@testable import Espresso
+
+final class QwenPrefillCompareTests: XCTestCase {
+    func test_seq64_and_seq256_are_the_fixed_prefill_shapes() {
+        XCTAssertEqual(QwenPrefillCompare.sequenceLengths, [64, 256])
+        XCTAssertEqual(QwenPrefillCompare.sequenceLengths, HybridDecodeKernelSet.prefillSequenceLengths)
+    }
+
+    func test_compiled_prefill_qkv_one_eval_matches_n1_hybrid_steps() throws {
+        guard ProcessInfo.processInfo.environment["ANE_HARDWARE_TESTS"] == "1" else {
+            throw XCTSkip("Set ANE_HARDWARE_TESTS=1 to run seq=64/256 HybridDecodeKernelSet prefill vs N=1 eval")
+        }
+        let weights = makePrefillCompareWeights()
+        for seq in QwenPrefillCompare.sequenceLengths {
+            let result: QwenPrefillCompareResult
+            do {
+                result = try QwenPrefillCompare.compareHybridQKV(sequenceLength: seq, weights: weights)
+            } catch {
+                throw XCTSkip("ANE prefill vs N=1 eval unavailable for seq=\(seq): \(error)")
+            }
+            print(
+                String(
+                    format: "hybrid_prefill_compare seq=%d n1_ms=%.6f batched_ms=%.6f outputs_match=%@ n1_count=%d batched_count=%d tol=%.4f",
+                    result.sequenceLength,
+                    result.n1WallMs,
+                    result.batchedWallMs,
+                    result.outputsMatch ? "true" : "false",
+                    result.n1Hidden.count,
+                    result.batchedHidden.count,
+                    result.matchTolerance
+                )
+            )
+            XCTAssertEqual(result.sequenceLength, seq)
+            XCTAssertEqual(result.n1Hidden.count, seq * weights.qDim)
+            XCTAssertTrue(
+                result.outputsMatch,
+                "seq=\(seq) batched QKV hidden diverged from N=1 hybrid QKV evals"
+            )
+            XCTAssertGreaterThan(result.n1WallMs, 0)
+            XCTAssertGreaterThan(result.batchedWallMs, 0)
+        }
+    }
+
+    func test_cpu_n1_loop_matches_batched_gemm_on_same_prompt_ids() {
+        for seq in QwenPrefillCompare.sequenceLengths {
+            let dim = 8
+            let out = 12
+            var input = [Float](repeating: 0, count: seq * dim)
+            var weights = [Float](repeating: 0, count: out * dim)
+            for i in input.indices { input[i] = Float(i % 7) * 0.1 }
+            for i in weights.indices { weights[i] = Float((i * 3) % 11) * 0.05 }
+            let result = QwenPrefillCompare.compareCPUMatmul(
+                sequenceLength: seq,
+                dim: dim,
+                outputChannels: out,
+                input: input,
+                weights: weights
+            )
+            print(
+                String(
+                    format: "prefill_compare seq=%d n1_ms=%.6f batched_ms=%.6f outputs_match=%@ n1_count=%d batched_count=%d",
+                    result.sequenceLength,
+                    result.n1WallMs,
+                    result.batchedWallMs,
+                    result.outputsMatch ? "true" : "false",
+                    result.n1Hidden.count,
+                    result.batchedHidden.count
+                )
+            )
+            XCTAssertEqual(result.sequenceLength, seq)
+            XCTAssertTrue(result.outputsMatch)
+            XCTAssertGreaterThanOrEqual(result.n1WallMs, 0)
+            XCTAssertGreaterThanOrEqual(result.batchedWallMs, 0)
+        }
+    }
+}
+
+private func makePrefillCompareWeights(value: Float = 0.01) -> LayerWeights {
+    let weights = LayerWeights()
+    func fill(_ buf: borrowing TensorBuffer, _ value: Float) {
+        buf.withUnsafeMutableBufferPointer { ptr in
+            for idx in ptr.indices {
+                ptr[idx] = value
+            }
+        }
+    }
+    fill(weights.Wq, value)
+    fill(weights.Wk, value)
+    fill(weights.Wv, value)
+    fill(weights.Wo, value)
+    fill(weights.W1, value)
+    fill(weights.W2, value)
+    fill(weights.W3, value)
+    fill(weights.rmsAtt, 1.0)
+    fill(weights.rmsFfn, 1.0)
+    return weights
+}

--- a/Tests/RealModelInferenceTests/EmissionCoreTests.swift
+++ b/Tests/RealModelInferenceTests/EmissionCoreTests.swift
@@ -59,6 +59,25 @@ private func makeEmission(
         #expect(emission.firstTokenLatencyMs == 4)
     }
 
+    @Test func emitPublishesGenerateClockPrefillAndTTFT() throws {
+        var steps: [GenerationStep] = []
+        var emission = EmissionCore(
+            promptTokens: [10],
+            capacity: 4,
+            eos: .fixed(50_256),
+            onStep: { steps.append($0) },
+            decodeText: { $0.map(String.init).joined() },
+            clock: GenerateClock(submitNS: 1_000_000_000)
+        )
+        emission.emit(7, at: 1_080_000_000)
+        let step = try #require(steps.first)
+        #expect(abs(step.prefillMs - 80) < 1e-9)
+        #expect(abs(step.firstTokenLatencyMs - 80) < 1e-9)
+        let result = emission.makeResult(compileTimeMs: 0)
+        #expect(abs(result.prefillMs - 80) < 1e-9)
+        #expect(result.firstTokenLatencyMs == result.ttftIncludingPrefillMs)
+    }
+
     // MARK: Concerns 1–3 — emit bookkeeping and step construction
 
     @Test func emitAppendsTokensRecordsLatenciesAndFiresSteps() throws {

--- a/Tests/RealModelInferenceTests/GenerateTimingTests.swift
+++ b/Tests/RealModelInferenceTests/GenerateTimingTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import RealModelInference
+
+@Test func test_generateClock_ttft_includes_prefill_and_is_not_head_only() {
+    final class Ticks: @unchecked Sendable {
+        var idx = 0
+        let values: [UInt64] = [0, 80_000_000, 101_000_000]
+        func next() -> UInt64 {
+            let value = values[min(idx, values.count - 1)]
+            idx += 1
+            return value
+        }
+    }
+    let ticks = Ticks()
+    var clock = GenerateClock(now: { ticks.next() })
+    clock.markPrefillEnd()
+    let headOnlyMs = 21.0
+    let timing = clock.timing(firstTokenNS: 101_000_000)
+
+    #expect(abs(timing.prefillMs - 80) < 1e-9)
+    #expect(abs(timing.ttftIncludingPrefillMs - 101) < 1e-9)
+    #expect(timing.ttftIncludingPrefillMs >= timing.prefillMs)
+    #expect(timing.firstTokenLatencyMs == timing.ttftIncludingPrefillMs)
+    #expect(timing.firstTokenLatencyMs != headOnlyMs)
+}
+
+@Test func test_generationResult_published_ttft_equals_including_prefill() throws {
+    let timing = GenerateTiming(prefillMs: 80, firstTokenLatencyIncludingPrefillMs: 101)
+    let result = GenerationResult(
+        text: "hi",
+        tokens: [1],
+        promptTokens: [9, 8, 7],
+        tokensPerSecond: 2,
+        compileTimeMs: 5,
+        firstTokenLatencyMs: timing.firstTokenLatencyMs,
+        prefillMs: timing.prefillMs,
+        exactHeadBackend: "cpu_fp16_tiled"
+    )
+    #expect(result.prefillMs == 80)
+    #expect(result.ttftIncludingPrefillMs >= result.prefillMs)
+    #expect(result.firstTokenLatencyMs == result.ttftIncludingPrefillMs)
+    #expect(result.firstTokenLatencyMs == 101)
+    let labeled = try result.withDecodePath("hybrid")
+    #expect(labeled.prefillMs == result.prefillMs)
+    #expect(labeled.firstTokenLatencyMs == result.firstTokenLatencyMs)
+}
+
+@Test func test_generationStep_published_ttft_includes_prefill() {
+    let step = GenerationStep(
+        token: 7,
+        generatedTokens: [7],
+        text: "hi",
+        tokenLatencyMs: 21,
+        elapsedMs: 21,
+        firstTokenLatencyMs: 101,
+        prefillMs: 80,
+        tokensPerSecond: 2
+    )
+    #expect(step.prefillMs == 80)
+    #expect(step.firstTokenLatencyMs >= step.prefillMs)
+    #expect(step.firstTokenLatencyMs == 101)
+}

--- a/research/docs/platform/2026-08-20-omlx-pr2853-cpu-amx-work-sharing.md
+++ b/research/docs/platform/2026-08-20-omlx-pr2853-cpu-amx-work-sharing.md
@@ -1,0 +1,167 @@
+# omlx PR #2853 → Espresso: CPU/AMX work sharing
+
+**Date:** 2026-08-20
+**Source:** [jundot/omlx#2853](https://github.com/jundot/omlx/pull/2853) (closed, unmerged; head `f640390`)
+**Question:** what transfers to Espresso TTFT and tok/s, what is our baseline, what would we actually get.
+
+This is a research note, not a product claim. Numbers below are either cited from the PR, from Espresso's checked-in artifacts, or labeled as estimates.
+
+## What the PR actually is
+
+Prefill-only hybrid for Qwen3.5/3.6/3.8 on M3 Ultra. Decode stays on GPU. Token-generation tok/s is unchanged by construction ([experimental doc](https://github.com/jundot/omlx/blob/f640390fcc378f50786d959dbfb5ecc3bcd784a6/docs/experimental/qwen35_ane_prefill.md)).
+
+Four devices in one MLP gate/up:
+
+1. ANE instance 1 (`kANEFAneInstanceHint = 1`)
+2. ANE instance 2 (`kANEFAneInstanceHint = 2`)
+3. Quantized GPU suffix (Metal, NAX on M5)
+4. Optional FP16 CPU AMX via `BNNSMatMul`
+
+CPU fractions are taken from the GPU suffix, not from the ANE slice. Gate/up, down projection, and residual GDN qkv have independent shares because they sit in different dependency windows.
+
+### Headline numbers (author, M3 Ultra, Qwen3.8-27B AWQ 4.85 bpw, 2048-token PP)
+
+| Config | Prompt tok/s | Versus |
+| --- | ---: | --- |
+| GPU only | 355.9 (tuner) / ~335–445 depending on run | — |
+| Dual ANE + GPU, CPU off | 460.1 | already-hybrid baseline |
+| + 13.5% gate/up CPU | 475.3 | +3.3% vs CPU-off |
+| + 13.5% gate/up + 20% down CPU | 494.7 | +7.5% vs CPU-off |
+| In-app 5-control tuner (45/14/20/45/13) | 517.9 | +45.8% vs that run's GPU-only |
+
+The +45.8% is **versus GPU-only**, not versus the already-hybrid ANE path. The CPU-AMX increment on top of dual-ANE is ~7.5%, and it costs peak RSS: ~31 GiB → ~50 GiB with the 20% down split.
+
+### The secrets that are not the split percentages
+
+**BNNS `n_threads` does not create AMX parallelism.** Isolated FP16 matmul, M3 Ultra (20P+8E, 6 clusters):
+
+| Mode | Workers | Median | Effective cores |
+| --- | ---: | ---: | ---: |
+| BNNS automatic | auto | 16.171 ms | 3.91 |
+| Manual aligned rows | 12 | 15.407 ms | 8.84 |
+| Shared-resource | 8 | **14.560 ms** | **6.67** |
+| Shared-resource | 16 | 14.423 ms | 13.00 |
+
+Eight workers capture almost all of the 16-worker throughput at half the CPU. Production hybrid: 5.715 ms vs 6.997 ms automatic (**+22.4% isolated**, bit-identical). Mixed P+E shards were a disaster (12 mixed: 35.16 ms vs 15.90 ms P-biased).
+
+Implementation: 64-row-aligned output shards, `BNNSFilterParameters.n_threads = 1`, `dispatch_apply` at `QOS_CLASS_USER_INTERACTIVE`, RAII `__bsdthread_ctl(0x2000, set/clear, worker_index, cluster_concurrency=2)`. Public Mach affinity was rejected by the kernel. Busy-spin core guards were rejected as unsafe. AMX occupancy is ~3 cores-equivalent on M3 Ultra; author reports no extra fan load.
+
+**Eager FP16 rows.** CPU-assigned output channels are dequantized once at load into a separate FP16 clone (`tools/clone_mlx_model_fp16.py`). Source checkpoint is never mutated. Trades RAM and load time for zero per-prompt dequant.
+
+**Procedure banks.** 64 MLP + 48 GDN slices packaged as 112 procedures in **two** resident `_ANEInMemoryModel`s (one per die). Single unpinned procedure of the same slice was 39.5% slower than two pinned evals. ~4 GiB ANE address window per die: dual 53%/50% 27B banks fit Ultra, fail on M3 Max with `0x20004`.
+
+**Host sync is hardware-dependent.**
+
+- M3 Ultra: blocking `waitUntilCompleted` on the pack buffer is **required**. Completion-handler / Metal-callback launch delayed ANE behind the GPU suffix and made the 64-layer body **5.6% slower than GPU-only**.
+- M5 Pro: the same two host waits per op (`commit` of MLX's shared stream + `model_->wait`) dominate. Dose-response: 64 MLP layers −17.6% real 16K TTFT vs GPU-only; 16 layers −2.5%. Tuner said +9.4%; interleaved real requests said −27.2% at 16K. The loss scaled with op count, not ANE work.
+
+**Tuner can invert the sign.** `measure_length = sequence_length * 2 + 1` produced `pp=4097` → two full ANE blocks and no GPU tail. Real traffic is `2048 ane + 2047 gpu`. Patching to `* 2` halved the phantom gain (claimed +10.6% → +5.11%). ArraysCache block size 2048 also clamped 4096-wide chunks whenever prefix cache was on.
+
+## Why we must not copy the recipe into Espresso decode
+
+| | omlx #2853 | Espresso today |
+| --- | --- | --- |
+| Goal metric | prompt-processing tok/s | decode tok/s + first-token wait |
+| Shape | fixed 2048-token GEMM | N=1 GEMV decode; prefill is the same N=1 loop |
+| Who owns FFN | GPU, with ANE stealing a prefix | ANE already owns QKV + SwiGLU |
+| Who owns attention | GPU | **CPU by default for Qwen/Llama** (`prefersCPUDecodeAttention`) |
+| Dual ANE | M3 Ultra, instance hints 1 and 2 | single `_ANEClient`, published numbers are M3 Max |
+| CPU role | AMX GEMM overlapping ANE+GPU | LM head (`cpu_fp16_tiled` / NEON GEMV) + RoPE + CPU attention |
+| Eval | threaded submit + events; still two host waits per op | `ANEKernel.eval()` → blocking `ane_interop_eval` |
+| Decode effect of this PR | none | n/a |
+
+Splitting N=1 Qwen FFN rows onto CPU AMX **takes work off the ANE**, which is already the right device for that GEMV. omlx's CPU share only paid because the GPU suffix was the limiter and ANE+GPU were already concurrent. On Espresso Qwen, the limiter at growing context is CPU attention (`docs/qwen15b-chat-name-recall.txt`: 2.1 tok/s @ ctx 51 → 0.3 tok/s @ ctx 367).
+
+The pipelined Metal path in `DecodeForwardPass.runHybridDecodeTimed` is commented as overlapping Metal SDPA[N] with ANE QKV[N+1], but the loop waits for Metal at the **start** of the next iteration before FFN[N] and QKV[N+1]. That is the same class of "sync before the merge" tax the M5 report called out.
+
+## Espresso baseline (do not mix lanes)
+
+### Shipping, M3 Max, `benchmarks/results/latest.json`
+
+| Lane | ms/tok | tok/s |
+| --- | ---: | ---: |
+| Recurrent fused 6-layer Stories | 1.929 | **519** |
+| Direct transformer 6-layer Stories | 6.559 | 153 |
+| CoreML `.cpuAndNeuralEngine` | 6.582 | 152 |
+
+TTFT is not in `latest.json`. Recurrent fused budget (blog, same artifact): embedding 0.05 + two 3-layer ANE dispatches 0.89 + ANE classifier 0.94 = 1.93 ms. Head is ~49% of that token.
+
+Research note (not a product claim): real Stories `.esp` serving was still ~100 tok/s on 2026-03-26.
+
+### Real-model serving, Qwen2.5-1.5B-Instruct hybrid
+
+From `docs/qwen15b-chat-name-recall.txt` (10-turn greedy chat, fallback disabled):
+
+| ctx | tok/s | reported TTFT |
+| ---: | ---: | ---: |
+| 51 | 2.1 | 59 ms |
+| 77 | 1.5 | 21 ms |
+| 138 | 0.9 | 23 ms |
+| 202–349 | 0.4–0.5 | 22–23 ms (one 91 ms) |
+| 367 | 0.3 | 108 ms |
+
+**Reported TTFT is not user-visible first-token wait.** `RealModelInferenceEngine` starts `generationStart` **after** the sequential N=1 prefill loop. `firstTokenLatencyMs` is the first LM head (~21 ms for the 151936×1536 fp16 head). Prefill of the whole history is excluded. Chat re-prefills growing history (`README`, `tasks/todo.md`).
+
+User-visible wait for a 50–300 token prompt is therefore "N_prompt sequential hybrid steps + ~21 ms head". At ~2 tok/s-equivalent prefill that is seconds, not 21 ms. This is the same class of harness lie as omlx's `pp=4097`.
+
+Qwen/Llama default: `prefersCPUDecodeAttention == true`. Metal fused SDPA exists but is not the Qwen default. Hybrid generate reports `cachedBindingsEnabled: false` on the Qwen path even when bindings were built.
+
+## What to steal, in order
+
+### 1. Redefine TTFT and stop publishing the LM-head-only number as chat TTFT
+
+Measure wall clock from prompt submit through first emitted token, including re-prefill. Until that exists, any "TTFT win" from an AMX head is a 21 ms microbench.
+
+### 2. Batched prefill kernels (the actual PR shape)
+
+Compile fixed-shape ANE GEMMs at seq ∈ {64, 128, 256} for Qwen QKV/FFN. Prefill the prompt as one or few GEMMs, not 28×2 blocking evals per token.
+
+This is where CPU AMX sharing can pay: leftover output channels of a **wide GEMM** overlap ANE, same as omlx. On M3 Max there is one ANE, so the split is ANE + CPU AMX + Metal attention, not dual-ANE.
+
+Directionally: user-visible TTFT on Qwen 1.5B 256-token prompts should drop from seconds toward a few hundred milliseconds if prefill becomes a handful of GEMMs. Exact multiplier needs a measured prefill profile; do not quote omlx's 45.8%.
+
+### 3. BNNS FP16 AMX row-shard for the Qwen LM head (small, isolated, portable)
+
+Replace `FP16TiledClassifier` / NEON `ane_interop_fp16_gemv_argmax` with the omlx recipe: eager FP16 rows (already the storage format), 64-row shards, `BNNSMatMul` n_threads=1, 8 workers, capability-guarded `__bsdthread_ctl`. Bit-identical vs current first-max rule is required.
+
+Expected: reported TTFT 21 ms → ~8–14 ms on M3 Max class. Decode tok/s at ctx 51 (476 ms/token) moves ~2–4%. At the Stories fused path the head is already on ANE; do not touch that lane.
+
+### 4. Do not sync until the merge — but profile first
+
+On Espresso Qwen, 28 layers × (QKV eval + FFN eval) blocking roundtrips. If host overhead is even 1–2 ms per eval, that is 56–112 ms dead per token **before** attention.
+
+True overlap: submit ANE QKV[L], run CPU/Metal attention[L] without waiting on a previous leftover, wait only before FFN[L]; or on Ultra, pin FFN[L] and QKV[L+1] to two dies. Copying omlx's blocking pack wait "because Ultra needed it" onto M-series Max/M5 would be the M5 footgun.
+
+Instrument `lastHWExecutionTimeNS` vs wall `eval()` per kernel before changing the wait model. Ultra and M5 disagreed in the PR thread.
+
+### 5. Hardware-local tuner, not a 14% constant
+
+Calibrate on one real layer (cheap bank), compile one predicted full model, verify on the **same chunk composition as chat** (including the GPU/CPU tail). CPU AMX will likely be rejected on M5 the way omlx's tuner did. Down-projection sharing stays off until RSS is budgeted.
+
+### 6. Explicitly out of scope for this PR's recipe
+
+- Dual-ANE procedure banks on M3 Max (address window).
+- Splitting N=1 decode FFN onto CPU.
+- INT8 requant of ANE weights (omlx is approximate; Espresso's Qwen contract is fp16 greedy parity).
+- Publishing omlx's 517.9 prompt tok/s next to Espresso's 519 decode tok/s. Different models, different phases, different chips.
+
+## Expected outcome if we proceed (ranges, not promises)
+
+| Work | Touches | vs current Qwen 1.5B hybrid | vs shipping Stories 519 |
+| --- | --- | --- | --- |
+| AMX LM head only | reported TTFT | 21 ms → 8–14 ms; tok/s +2–8% | none (head already ANE) |
+| Batched prefill, ANE only | user-visible TTFT | likely 5–20× on the prefill portion | none |
+| Batched prefill + CPU AMX share | user-visible TTFT | extra ~5–15% on top of batched ANE, Ultra/Max class; 0 or negative on M5 | none |
+| Dual ANE banks | Ultra prefill only | omlx-like 1.2–1.4× PP; **cannot load on M3 Max** | none |
+| True device overlap (no per-op host wait) | decode tok/s | 1.3–2× **if** wall-eval >> hw-eval; else ~0 | modest (already 2 fused dispatches) |
+| Default Metal SDPA for Qwen (not this PR, but the actual tok/s limiter) | decode tok/s | likely 3–10× as ctx grows; 2.1→0.3 is O(n) CPU attention | n/a |
+
+**Honest ceiling:** this PR is a prefill-GEMM and AMX-scheduling paper. It does not contain a decode tok/s win. Espresso's Qwen tok/s problem is CPU attention + blocking N=1 eval. Espresso's Qwen TTFT problem is sequential prefill plus a mis-labeled 21 ms head. Steal the AMX shard recipe and the "tune on real traffic" discipline; do not steal the 14/20/13 split table.
+
+## Proof plan if we implement
+
+1. Add a generate-path counter: `prefill_ms`, `ttft_including_prefill_ms`, `decode_tok_s`, per-kernel `eval_wall_us` vs `hw_ns`.
+2. Microbench BNNS FP16 sharded GEMV vs current tiled/NEON head on the 1.5B classifier, bit-identical argmax.
+3. One fixed-shape seq=64 Qwen FFN prefill kernel vs the current 64-step N=1 loop on the same prompt IDs.
+4. Interleave ON/OFF on a heat-soaked machine. Never quote a tuner percentage without the absolute tok/s and the chunk trace.
+5. Keep Qwen greedy parity (`docs/qwen15b-parity.md`) as the quality gate. INT8 ANE prefixes are incompatible with that gate.


### PR DESCRIPTION
## Summary

Generate/chat TTFT was the LM-head wait after sequential N=1 prefill. This starts the clock at prompt submit, reports `prefill_ms`, and publishes TTFT as submit → first token (including prefill). Decode tok/s stays post-prefill.

Follow-on work from omlx #2853 research (not a copied 14/20/13 split): BNNS FP16 8-shard LM head, fixed-shape seq=64/256 hybrid QKV prefill vs N=1 QKV evals, leftover-channel AMX share on batched prefill GEMM only, tuned from chat chunk mix.

## Changes

- `GenerationResult.prefillMs` / `GenerateClock`; hybrid generate starts the clock before prefill; chat footer and generate JSON publish including-prefill TTFT
- `ANEKernel.eval()` records host wall next to `lastHWExecutionTimeNS` (0 when perf stats are off)
- Isolated BNNS FP16 8-shard classifier (`n_threads=1`, first-max, 8 shards); Stories ANE classifier unchanged
- `HybridDecodeKernelSet(prefillWeights:sequenceLength:)` at 64 and 256; `QwenPrefillCompare.compareHybridQKV` runs one batched QKV eval against N=1 `decodeQKVOnly.eval` on the same prompt IDs
- `PrefillAMXShareTuner` reads chat chunk mix; leftover channels of batched prefill GEMM only — never N=1 decode FFN, never omlx 14/20/13
- Research note: `research/docs/platform/2026-08-20-omlx-pr2853-cpu-amx-work-sharing.md`

## Testing

- [x] Targeted unit tests pass (`swift test --filter` on GenerateTiming, chat footer/JSON TTFT, ANEEvalTiming, BNNS 8-shard, PrefillAMXShare, QwenPrefillCompare)
- [x] Hardware tests where they could run (`ANE_HARDWARE_TESTS=1`): seq=64/256 prefill kernels compile; `compareHybridQKV` match (seq=64: 24.4 ms N=1 vs 0.70 ms batched; seq=256: 78.5 vs 1.64 ms); hybrid QKV `eval()` recorded wall 496.6 µs, hw_ns=0 (perf stats off)
- [x] New code has test coverage
- [ ] Full `swift test` not run (targeted filters only)
- Identity-kernel eval skipped on this host (ANE `0x1d`)
- `./espresso generate` on Qwen 1.5B skipped — no `.esp` at `~/Library/Caches/Espresso/qwen25-15b/`

## Benchmark impact

None / N/A. No README or `benchmarks/results/latest.json` claim. Decode tok/s is unchanged by construction. Prefill vs N=1 QKV numbers above are hardware-local evidence, not a product claim.

## Checklist

- [x] Code compiles under Swift 6.2 strict concurrency (`.swiftLanguageMode(.v6)`)
- [x] No external dependencies added (Accelerate/BNNS only)
- [ ] Files ≤400 lines, functions ≤50 lines — `RealModelInferenceEngine.swift` was already far over that; new files are under 400
- [x] Commit messages follow `type: summary` convention