### PR TITLE
Introduce canonical Trunk enum for llama serving

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,27 @@
+# Espresso
+
+Direct Neural Engine inference for transformers on Apple Silicon. Terms here name serving and decode concepts, not Swift types.
+
+## Language
+
+**Llama serving session**:
+One llama-family serving run: compiled decode programs plus the token loop that consumes prompt token ids and emits tokens.
+_Avoid_: decode session, serving runtime, generation harness
+
+**Trunk**:
+Which decode-step implementation a llama serving session uses for each token: fused hybrid, split hybrid, or exact-CPU.
+_Avoid_: path, backend, lane
+
+**Decode step**:
+One generated token's worth of hidden-state update and KV-cache write.
+_Avoid_: generate, forward pass, eval
+
+**Fused hybrid**:
+A decode step that runs one ANE program per transformer layer, attention included.
+
+**Split hybrid**:
+A decode step that runs ANE QKV, then host attention, then ANE FFN.
+
+**Exact-CPU**:
+A decode step that runs the transformer layer on the CPU. Also the Qwen oracle.
+_Avoid_: CPU exact, cpu_fp16_tiled (that is a classifier, not a trunk)

--- a/Sources/ANERuntime/FusedHybridDecodeLayerKernelSet.swift
+++ b/Sources/ANERuntime/FusedHybridDecodeLayerKernelSet.swift
@@ -6,6 +6,7 @@ import MILGenerator
 /// One compiled Phase-11 `max_N = 1` fused layer (QKV + attention + FFN).
 public struct FusedHybridDecodeLayerKernelSet: ~Copyable {
     public static let phase11MaxN = 1
+    /// Telemetry label; must stay aligned with `Trunk.fusedHybrid.rawValue` in ModelSupport.
     public static let decodePathLabel = "fused"
     public static let fallbackStage = "fused_hybrid_decode"
 

--- a/Sources/EspressoGenerate/ChatSession.swift
+++ b/Sources/EspressoGenerate/ChatSession.swift
@@ -116,8 +116,14 @@ func chatForcesHybridFallbackDisable(_ options: Options) -> Bool {
 }
 
 func assertChatDecodePathIsHybrid(_ path: String) throws {
-    let normalized = path.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    guard normalized == "hybrid" || normalized == "fused" else {
+    do {
+        let trunk = try Trunk.parseTelemetryLabel(path)
+        guard trunk.isHybrid else {
+            throw CLIError.runtime(
+                "chat requires path=hybrid or path=fused (ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK=1); got \(path)"
+            )
+        }
+    } catch is Trunk.ParseError {
         throw CLIError.runtime(
             "chat requires path=hybrid or path=fused (ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK=1); got \(path)"
         )

--- a/Sources/ModelSupport/MultiModelConfig.swift
+++ b/Sources/ModelSupport/MultiModelConfig.swift
@@ -16,11 +16,14 @@ public struct MultiModelConfig: Sendable, Equatable {
     public let eosToken: TokenID?
     public let architecture: Architecture
 
-    /// What the artifact itself declares about where it should decode.
+    /// Coarse artifact preference for decode placement (hybrid family vs exact-CPU).
     ///
     /// When an artifact states this, the runtime honours it instead of guessing from the
     /// model name. `nil` means the artifact is silent and legacy name-based routing
     /// applies, which keeps older bundles behaving exactly as before.
+    ///
+    /// Fused vs split hybrid is **not** declared here — that is runtime policy resolved
+    /// into ``Trunk``. See ``Trunk`` and `CONTEXT.md`.
     public let preferredDecodePath: PreferredDecodePath?
 
     public var attentionDim: Int { nHead * headDim }
@@ -31,6 +34,10 @@ public struct MultiModelConfig: Sendable, Equatable {
         case llama
     }
 
+    /// Wire-format preference in `metadata.json` / bundle manifests.
+    ///
+    /// Only distinguishes the ANE hybrid family from exact-CPU. Resolved serving uses
+    /// ``Trunk`` (`fusedHybrid` | `splitHybrid` | `exactCPU`).
     public enum PreferredDecodePath: String, Sendable, Equatable {
         case hybrid
         case exactCPU = "exact_cpu"

--- a/Sources/ModelSupport/Trunk.swift
+++ b/Sources/ModelSupport/Trunk.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Which decode-step implementation a llama serving session uses for each token.
+///
+/// Matches the domain vocabulary in `CONTEXT.md`:
+/// - ``fusedHybrid`` — one ANE program per transformer layer, attention included
+/// - ``splitHybrid`` — ANE QKV, host attention, ANE FFN
+/// - ``exactCPU`` — transformer layer on the CPU (also the Qwen oracle)
+///
+/// Telemetry / CLI labels use the stable `rawValue` strings (`fused`, `hybrid`, `exact_cpu`).
+/// Artifact metadata still uses ``MultiModelConfig/PreferredDecodePath``, which only
+/// distinguishes the hybrid family from exact-CPU; fused vs split is runtime policy.
+public enum Trunk: String, Sendable, Equatable, CaseIterable {
+    case fusedHybrid = "fused"
+    case splitHybrid = "hybrid"
+    case exactCPU = "exact_cpu"
+
+    /// ANE hybrid trunks (fused or split), as opposed to exact-CPU.
+    public var isHybrid: Bool {
+        switch self {
+        case .fusedHybrid, .splitHybrid:
+            return true
+        case .exactCPU:
+            return false
+        }
+    }
+
+    /// Stable label for `decode_path=` stderr / JSON contracts.
+    public var telemetryLabel: String { rawValue }
+
+    /// Parse a telemetry or CLI path label into a trunk.
+    public static func parseTelemetryLabel(_ raw: String) throws -> Trunk {
+        let normalized = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard let value = Trunk(rawValue: normalized) else {
+            throw ParseError.unsupported(raw)
+        }
+        return value
+    }
+
+    public enum ParseError: Error, Sendable, Equatable, LocalizedError {
+        case unsupported(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case let .unsupported(raw):
+                return "Unsupported trunk label: \(raw) (expected \"fused\", \"hybrid\", or \"exact_cpu\")"
+            }
+        }
+    }
+}
+
+extension MultiModelConfig.PreferredDecodePath {
+    /// Coarse artifact preference maps onto the exact-CPU trunk or the hybrid family.
+    /// Fused vs split is chosen later by runtime policy, not by metadata.
+    public var exactCPUTrunk: Trunk? {
+        self == .exactCPU ? .exactCPU : nil
+    }
+
+    public var prefersHybridFamily: Bool {
+        self == .hybrid
+    }
+}

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -26,12 +26,18 @@ public struct GenerationResult: Sendable {
     public let cachedBindingsEnabled: Bool
     public let committedExactTokensPerPass: Double?
     public let acceptedFutureTokensPerPass: Double?
-    /// `"hybrid"`, `"fused"`, or `"exact_cpu"` for llama generate paths; `"unknown"` otherwise.
-    public let decodePath: String
+    /// Resolved llama serving trunk. `nil` when the run is not on a typed llama trunk
+    /// (for example GPT-2), which telemetry still reports as `"unknown"`.
+    public let trunk: Trunk?
     /// ANE hops per generated token. Fused N=1 is `nLayer`; split hybrid is `2 * nLayer`.
     public let hopsPerToken: Int?
     /// Hybrid per-token bucket report from `HybridDecodeTokenProfile.formatReport()`.
     public let decodeProfileReport: String?
+
+    /// Stable telemetry label: `Trunk.telemetryLabel`, or `"unknown"` when `trunk` is nil.
+    public var decodePath: String {
+        trunk?.telemetryLabel ?? "unknown"
+    }
 
     public init(
         text: String,
@@ -45,7 +51,7 @@ public struct GenerationResult: Sendable {
         cachedBindingsEnabled: Bool = false,
         committedExactTokensPerPass: Double? = nil,
         acceptedFutureTokensPerPass: Double? = nil,
-        decodePath: String = "unknown",
+        trunk: Trunk? = nil,
         hopsPerToken: Int? = nil,
         decodeProfileReport: String? = nil
     ) {
@@ -60,12 +66,53 @@ public struct GenerationResult: Sendable {
         self.cachedBindingsEnabled = cachedBindingsEnabled
         self.committedExactTokensPerPass = committedExactTokensPerPass
         self.acceptedFutureTokensPerPass = acceptedFutureTokensPerPass
-        self.decodePath = decodePath
+        self.trunk = trunk
         self.hopsPerToken = hopsPerToken
         self.decodeProfileReport = decodeProfileReport
     }
 
-    public func withDecodePath(_ path: String) -> GenerationResult {
+    /// Compatibility initializer that accepts a telemetry path label.
+    public init(
+        text: String,
+        tokens: [TokenID],
+        promptTokens: [TokenID],
+        tokenLatenciesMs: [Double] = [],
+        tokensPerSecond: Double,
+        compileTimeMs: Double,
+        firstTokenLatencyMs: Double,
+        exactHeadBackend: String = "unknown",
+        cachedBindingsEnabled: Bool = false,
+        committedExactTokensPerPass: Double? = nil,
+        acceptedFutureTokensPerPass: Double? = nil,
+        decodePath: String,
+        hopsPerToken: Int? = nil,
+        decodeProfileReport: String? = nil
+    ) {
+        let resolvedTrunk: Trunk?
+        if decodePath == "unknown" {
+            resolvedTrunk = nil
+        } else {
+            resolvedTrunk = try? Trunk.parseTelemetryLabel(decodePath)
+        }
+        self.init(
+            text: text,
+            tokens: tokens,
+            promptTokens: promptTokens,
+            tokenLatenciesMs: tokenLatenciesMs,
+            tokensPerSecond: tokensPerSecond,
+            compileTimeMs: compileTimeMs,
+            firstTokenLatencyMs: firstTokenLatencyMs,
+            exactHeadBackend: exactHeadBackend,
+            cachedBindingsEnabled: cachedBindingsEnabled,
+            committedExactTokensPerPass: committedExactTokensPerPass,
+            acceptedFutureTokensPerPass: acceptedFutureTokensPerPass,
+            trunk: resolvedTrunk,
+            hopsPerToken: hopsPerToken,
+            decodeProfileReport: decodeProfileReport
+        )
+    }
+
+    public func withTrunk(_ trunk: Trunk?) -> GenerationResult {
         GenerationResult(
             text: text,
             tokens: tokens,
@@ -78,10 +125,17 @@ public struct GenerationResult: Sendable {
             cachedBindingsEnabled: cachedBindingsEnabled,
             committedExactTokensPerPass: committedExactTokensPerPass,
             acceptedFutureTokensPerPass: acceptedFutureTokensPerPass,
-            decodePath: path,
+            trunk: trunk,
             hopsPerToken: hopsPerToken,
             decodeProfileReport: decodeProfileReport
         )
+    }
+
+    public func withDecodePath(_ path: String) -> GenerationResult {
+        if path == "unknown" {
+            return withTrunk(nil)
+        }
+        return withTrunk(try? Trunk.parseTelemetryLabel(path))
     }
 }
 
@@ -238,7 +292,7 @@ public struct RealModelInferenceEngine: ~Copyable {
 
     /// Phase 11 compiled `max_N = 1` only. Serve that N: one fused program per
     /// layer with attention in-graph (28 hops, no Metal QKV↔FFN sync).
-    static let fusedDecodePathLabel = FusedHybridDecodeLayerKernelSet.decodePathLabel
+    static let fusedDecodePathLabel = Trunk.fusedHybrid.telemetryLabel
     static let fusedHybridFallbackStage = FusedHybridDecodeLayerKernelSet.fallbackStage
 
     static func prefersFusedHybridDecode(
@@ -442,18 +496,18 @@ public struct RealModelInferenceEngine: ~Copyable {
         environment["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK"] == "1"
     }
 
-    /// Resolves the llama decode path, refusing to leave the ANE silently.
+    /// Resolves the llama serving ``Trunk``, refusing to leave the ANE silently.
     ///
-    /// With `ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK=1`, landing on the pure-CPU path is
+    /// With `ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK=1`, landing on the pure-CPU trunk is
     /// a failure rather than a quiet downgrade, and the thrown error names which policy
     /// chose CPU so the cause is actionable instead of mysterious.
-    static func resolvedLlamaGenerationPath(
+    static func resolvedTrunk(
         config: MultiModelConfig,
         environment: [String: String]
-    ) throws -> LlamaGenerationPath {
-        let path = llamaGenerationPath(config: config, environment: environment)
-        guard path == .exactCPU, isHybridFallbackDisabled(environment: environment) else {
-            return path
+    ) throws -> Trunk {
+        let trunk = selectTrunk(config: config, environment: environment)
+        guard trunk == .exactCPU, isHybridFallbackDisabled(environment: environment) else {
+            return trunk
         }
         let reason: String
         if environment["ESPRESSO_USE_CPU_EXACT_DECODE"] == "1" {
@@ -468,9 +522,17 @@ public struct RealModelInferenceEngine: ~Copyable {
                 """
         }
         throw RealModelInferenceError.hybridFallbackDisabled(
-            stage: "llama decode path selection",
+            stage: "llama trunk selection",
             reason: reason
         )
+    }
+
+    /// Backward-compatible alias for ``resolvedTrunk``.
+    static func resolvedLlamaGenerationPath(
+        config: MultiModelConfig,
+        environment: [String: String]
+    ) throws -> Trunk {
+        try resolvedTrunk(config: config, environment: environment)
     }
 
     static func milDeploymentTarget(
@@ -515,16 +577,36 @@ public struct RealModelInferenceEngine: ~Copyable {
         return .normThenClassifier
     }
 
-    enum LlamaGenerationPath: Sendable, Equatable {
-        case hybrid
-        case exactCPU
+    /// Select the serving trunk for a llama-family config (no fallback-disabled gate).
+    static func selectTrunk(
+        config: MultiModelConfig,
+        environment: [String: String]
+    ) -> Trunk {
+        if prefersCPUExactDecode(config: config, environment: environment) {
+            return .exactCPU
+        }
+        if prefersFusedHybridDecode(config: config, environment: environment) {
+            return .fusedHybrid
+        }
+        return .splitHybrid
     }
 
+    /// Backward-compatible family discriminator used by older tests and call sites.
+    /// Prefer ``selectTrunk`` / ``resolvedTrunk`` for new code.
     static func llamaGenerationPath(
         config: MultiModelConfig,
         environment: [String: String]
-    ) -> LlamaGenerationPath {
-        prefersCPUExactDecode(config: config, environment: environment) ? .exactCPU : .hybrid
+    ) -> Trunk {
+        selectTrunk(config: config, environment: environment)
+    }
+
+    static func hopsPerToken(for trunk: Trunk, nLayer: Int) -> Int? {
+        switch trunk {
+        case .fusedHybrid:
+            return fusedHopsPerToken(nLayer: nLayer)
+        case .splitHybrid, .exactCPU:
+            return nil
+        }
     }
 
     struct TopLevelWeightPaths: Sendable, Equatable {
@@ -1643,21 +1725,14 @@ public struct RealModelInferenceEngine: ~Copyable {
         let environment = ProcessInfo.processInfo.environment
         if effectiveMaxTokens == 0 {
             let text = tokenizer.decode(promptTokens.map(Int.init))
-            let decodePath: String
+            let trunk: Trunk?
             let hopsPerToken: Int?
             if config.architecture == .llama {
-                if Self.llamaGenerationPath(config: config, environment: environment) == .exactCPU {
-                    decodePath = "exact_cpu"
-                    hopsPerToken = nil
-                } else if Self.prefersFusedHybridDecode(config: config, environment: environment) {
-                    decodePath = Self.fusedDecodePathLabel
-                    hopsPerToken = Self.fusedHopsPerToken(nLayer: config.nLayer)
-                } else {
-                    decodePath = "hybrid"
-                    hopsPerToken = nil
-                }
+                let selected = Self.selectTrunk(config: config, environment: environment)
+                trunk = selected
+                hopsPerToken = Self.hopsPerToken(for: selected, nLayer: config.nLayer)
             } else {
-                decodePath = "unknown"
+                trunk = nil
                 hopsPerToken = nil
             }
             return GenerationResult(
@@ -1667,7 +1742,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 tokensPerSecond: 0,
                 compileTimeMs: 0,
                 firstTokenLatencyMs: 0,
-                decodePath: decodePath,
+                trunk: trunk,
                 hopsPerToken: hopsPerToken
             )
         }
@@ -1694,7 +1769,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     onStep: onStep
                 )
             }
-            switch try Self.resolvedLlamaGenerationPath(
+            switch try Self.resolvedTrunk(
                 config: config,
                 environment: environment
             ) {
@@ -1709,33 +1784,32 @@ public struct RealModelInferenceEngine: ~Copyable {
                     onStep: onStep,
                     isCancelled: isCancelled
                 )
-            case .hybrid:
-                if Self.prefersFusedHybridDecode(config: config, environment: environment) {
-                    let compileStart = DispatchTime.now().uptimeNanoseconds
-                    let compileDidRun: Bool
-                    do {
-                        compileDidRun = try ensureFusedHybridCompiled(bucket: bucket)
-                    } catch let error as RealModelInferenceError {
-                        if case .hybridFallbackDisabled = error { throw error }
-                        throw Self.fusedHybridFallbackError(
-                            reason: error.errorDescription ?? "\(error)"
-                        )
-                    } catch {
-                        throw Self.fusedHybridFallbackError(reason: "\(error)")
-                    }
-                    let compileEnd = DispatchTime.now().uptimeNanoseconds
-                    let compileTimeMs = compileDidRun ? Self.milliseconds(from: compileEnd - compileStart) : 0
-                    return try generateIncrementalFusedHybridLlama(
-                        promptTokens: promptTokens,
-                        effectiveMaxTokens: effectiveMaxTokens,
-                        temperature: temperature,
-                        topP: topP,
-                        compileTimeMs: compileTimeMs,
-                        maxSeq: max(bucket, compiledFusedHybridBucket),
-                        onStep: onStep,
-                        isCancelled: isCancelled
+            case .fusedHybrid:
+                let compileStart = DispatchTime.now().uptimeNanoseconds
+                let compileDidRun: Bool
+                do {
+                    compileDidRun = try ensureFusedHybridCompiled(bucket: bucket)
+                } catch let error as RealModelInferenceError {
+                    if case .hybridFallbackDisabled = error { throw error }
+                    throw Self.fusedHybridFallbackError(
+                        reason: error.errorDescription ?? "\(error)"
                     )
+                } catch {
+                    throw Self.fusedHybridFallbackError(reason: "\(error)")
                 }
+                let compileEnd = DispatchTime.now().uptimeNanoseconds
+                let compileTimeMs = compileDidRun ? Self.milliseconds(from: compileEnd - compileStart) : 0
+                return try generateIncrementalFusedHybridLlama(
+                    promptTokens: promptTokens,
+                    effectiveMaxTokens: effectiveMaxTokens,
+                    temperature: temperature,
+                    topP: topP,
+                    compileTimeMs: compileTimeMs,
+                    maxSeq: max(bucket, compiledFusedHybridBucket),
+                    onStep: onStep,
+                    isCancelled: isCancelled
+                )
+            case .splitHybrid:
                 let compileStart = DispatchTime.now().uptimeNanoseconds
                 let compileDidRun = try ensureHybridCompiledLlama(bucket: bucket)
                 guard let metalAttention = hybridMetalAttention else {
@@ -2090,17 +2164,14 @@ public struct RealModelInferenceEngine: ~Copyable {
         )
 
         let environment = ProcessInfo.processInfo.environment
-        let path = try resolvedLlamaGenerationPath(
-            config: config,
-            environment: environment
-        )
-        let useFused = path == .hybrid && prefersFusedHybridDecode(
+        let trunk = try resolvedTrunk(
             config: config,
             environment: environment
         )
         var compileTimeMs = 0.0
         var metalAttention: MetalAttentionKernel?
-        if useFused {
+        switch trunk {
+        case .fusedHybrid:
             let compileStart = DispatchTime.now().uptimeNanoseconds
             let compileDidRun: Bool
             do {
@@ -2113,7 +2184,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
             let compileEnd = DispatchTime.now().uptimeNanoseconds
             compileTimeMs = compileDidRun ? milliseconds(from: compileEnd - compileStart) : 0
-        } else if path == .hybrid {
+        case .splitHybrid:
             let compileStart = DispatchTime.now().uptimeNanoseconds
             let compileDidRun = try engine.ensureHybridCompiledLlama(bucket: bucket)
             guard let attention = engine.hybridMetalAttention else {
@@ -2122,6 +2193,8 @@ public struct RealModelInferenceEngine: ~Copyable {
             metalAttention = attention
             let compileEnd = DispatchTime.now().uptimeNanoseconds
             compileTimeMs = compileDidRun ? milliseconds(from: compileEnd - compileStart) : 0
+        case .exactCPU:
+            break
         }
 
         var results: [GenerationResult] = []
@@ -2133,7 +2206,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     "Prompt of \(prompt.count) tokens leaves no room to generate within context \(config.maxSeq)"
                 )
             }
-            switch path {
+            switch trunk {
             case .exactCPU:
                 results.append(
                     try engine.generateIncrementalExactCPULlama(
@@ -2145,52 +2218,50 @@ public struct RealModelInferenceEngine: ~Copyable {
                         onStep: nil
                     )
                 )
-            case .hybrid:
-                if useFused {
-                    let result = try engine.generateIncrementalFusedHybridLlama(
+            case .fusedHybrid:
+                let result = try engine.generateIncrementalFusedHybridLlama(
+                    promptTokens: prompt,
+                    effectiveMaxTokens: effectiveMaxTokens,
+                    temperature: 0,
+                    compileTimeMs: results.isEmpty ? compileTimeMs : 0,
+                    maxSeq: max(bucket, engine.compiledFusedHybridBucket),
+                    onStep: nil
+                )
+                // Drop the profile string so the next ANE eval cannot smash a
+                // heap object that must survive the whole suite.
+                results.append(
+                    GenerationResult(
+                        text: result.text,
+                        tokens: result.tokens,
+                        promptTokens: result.promptTokens,
+                        tokenLatenciesMs: result.tokenLatenciesMs,
+                        tokensPerSecond: result.tokensPerSecond,
+                        compileTimeMs: result.compileTimeMs,
+                        firstTokenLatencyMs: result.firstTokenLatencyMs,
+                        exactHeadBackend: result.exactHeadBackend,
+                        cachedBindingsEnabled: result.cachedBindingsEnabled,
+                        committedExactTokensPerPass: result.committedExactTokensPerPass,
+                        acceptedFutureTokensPerPass: result.acceptedFutureTokensPerPass,
+                        trunk: result.trunk,
+                        hopsPerToken: result.hopsPerToken,
+                        decodeProfileReport: nil
+                    )
+                )
+            case .splitHybrid:
+                guard let attention = metalAttention else {
+                    throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention unavailable for llama testing helper")
+                }
+                results.append(
+                    try engine.generateIncrementalHybridLlama(
                         promptTokens: prompt,
                         effectiveMaxTokens: effectiveMaxTokens,
                         temperature: 0,
                         compileTimeMs: results.isEmpty ? compileTimeMs : 0,
-                        maxSeq: max(bucket, engine.compiledFusedHybridBucket),
+                        maxSeq: bucket,
+                        metalAttention: attention,
                         onStep: nil
                     )
-                    // Drop the profile string so the next ANE eval cannot smash a
-                    // heap object that must survive the whole suite.
-                    results.append(
-                        GenerationResult(
-                            text: result.text,
-                            tokens: result.tokens,
-                            promptTokens: result.promptTokens,
-                            tokenLatenciesMs: result.tokenLatenciesMs,
-                            tokensPerSecond: result.tokensPerSecond,
-                            compileTimeMs: result.compileTimeMs,
-                            firstTokenLatencyMs: result.firstTokenLatencyMs,
-                            exactHeadBackend: result.exactHeadBackend,
-                            cachedBindingsEnabled: result.cachedBindingsEnabled,
-                            committedExactTokensPerPass: result.committedExactTokensPerPass,
-                            acceptedFutureTokensPerPass: result.acceptedFutureTokensPerPass,
-                            decodePath: result.decodePath,
-                            hopsPerToken: result.hopsPerToken,
-                            decodeProfileReport: nil
-                        )
-                    )
-                } else {
-                    guard let attention = metalAttention else {
-                        throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention unavailable for llama testing helper")
-                    }
-                    results.append(
-                        try engine.generateIncrementalHybridLlama(
-                            promptTokens: prompt,
-                            effectiveMaxTokens: effectiveMaxTokens,
-                            temperature: 0,
-                            compileTimeMs: results.isEmpty ? compileTimeMs : 0,
-                            maxSeq: bucket,
-                            metalAttention: attention,
-                            onStep: nil
-                        )
-                    )
-                }
+                )
             }
         }
         return results
@@ -6140,7 +6211,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
             cachedBindingsEnabled: false,
-            decodePath: Self.fusedDecodePathLabel,
+            trunk: .fusedHybrid,
             hopsPerToken: hopsPerToken,
             decodeProfileReport: decodeProfileReport
         )
@@ -6662,7 +6733,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 ? "ane_factored_classifier"
                 : classifierStrategy.exactHeadBackendLabel,
             cachedBindingsEnabled: cachedBindings != nil,
-            decodePath: "hybrid",
+            trunk: .splitHybrid,
             decodeProfileReport: decodeProfileReport
         )
     }
@@ -6781,7 +6852,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 cachedBindingsEnabled: false,
                 committedExactTokensPerPass: nil,
                 acceptedFutureTokensPerPass: nil,
-                decodePath: "exact_cpu"
+                trunk: .exactCPU
             )
         }
         let firstEmission = DispatchTime.now().uptimeNanoseconds
@@ -6801,7 +6872,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 cachedBindingsEnabled: false,
                 committedExactTokensPerPass: nil,
                 acceptedFutureTokensPerPass: nil,
-                decodePath: "exact_cpu"
+                trunk: .exactCPU
             )
         }
 
@@ -6888,7 +6959,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             cachedBindingsEnabled: false,
             committedExactTokensPerPass: committedExactTokensPerPass,
             acceptedFutureTokensPerPass: acceptedFutureTokensPerPass,
-            decodePath: "exact_cpu"
+            trunk: .exactCPU
         )
     }
 
@@ -7027,7 +7098,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             compileTimeMs: compileTimeMs,
             firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
-            decodePath: "exact_cpu"
+            trunk: .exactCPU
         )
     }
 

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -72,6 +72,9 @@ public struct GenerationResult: Sendable {
     }
 
     /// Compatibility initializer that accepts a telemetry path label.
+    ///
+    /// - Throws: ``Trunk/ParseError`` when `decodePath` is not `"unknown"` and not a known
+    ///   trunk label. Prefer the `trunk:` initializer for new code.
     public init(
         text: String,
         tokens: [TokenID],
@@ -87,12 +90,12 @@ public struct GenerationResult: Sendable {
         decodePath: String,
         hopsPerToken: Int? = nil,
         decodeProfileReport: String? = nil
-    ) {
+    ) throws {
         let resolvedTrunk: Trunk?
         if decodePath == "unknown" {
             resolvedTrunk = nil
         } else {
-            resolvedTrunk = try? Trunk.parseTelemetryLabel(decodePath)
+            resolvedTrunk = try Trunk.parseTelemetryLabel(decodePath)
         }
         self.init(
             text: text,
@@ -131,11 +134,14 @@ public struct GenerationResult: Sendable {
         )
     }
 
-    public func withDecodePath(_ path: String) -> GenerationResult {
+    /// Compatibility helper that parses a telemetry path label into ``trunk``.
+    ///
+    /// - Throws: ``Trunk/ParseError`` when `path` is not `"unknown"` and not a known trunk label.
+    public func withDecodePath(_ path: String) throws -> GenerationResult {
         if path == "unknown" {
             return withTrunk(nil)
         }
-        return withTrunk(try? Trunk.parseTelemetryLabel(path))
+        return withTrunk(try Trunk.parseTelemetryLabel(path))
     }
 }
 
@@ -527,14 +533,6 @@ public struct RealModelInferenceEngine: ~Copyable {
         )
     }
 
-    /// Backward-compatible alias for ``resolvedTrunk``.
-    static func resolvedLlamaGenerationPath(
-        config: MultiModelConfig,
-        environment: [String: String]
-    ) throws -> Trunk {
-        try resolvedTrunk(config: config, environment: environment)
-    }
-
     static func milDeploymentTarget(
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> String {
@@ -589,15 +587,6 @@ public struct RealModelInferenceEngine: ~Copyable {
             return .fusedHybrid
         }
         return .splitHybrid
-    }
-
-    /// Backward-compatible family discriminator used by older tests and call sites.
-    /// Prefer ``selectTrunk`` / ``resolvedTrunk`` for new code.
-    static func llamaGenerationPath(
-        config: MultiModelConfig,
-        environment: [String: String]
-    ) -> Trunk {
-        selectTrunk(config: config, environment: environment)
     }
 
     static func hopsPerToken(for trunk: Trunk, nLayer: Int) -> Int? {
@@ -1672,10 +1661,11 @@ public struct RealModelInferenceEngine: ~Copyable {
         )
         switch config.architecture {
         case .llama:
-            if Self.prefersFusedHybridDecode(
+            switch Self.selectTrunk(
                 config: config,
                 environment: ProcessInfo.processInfo.environment
             ) {
+            case .fusedHybrid:
                 do {
                     _ = try ensureFusedHybridCompiled(bucket: bucket)
                 } catch let error as RealModelInferenceError {
@@ -1686,8 +1676,10 @@ public struct RealModelInferenceEngine: ~Copyable {
                 } catch {
                     throw Self.fusedHybridFallbackError(reason: "\(error)")
                 }
-            } else {
+            case .splitHybrid:
                 _ = try ensureHybridCompiledLlama(bucket: bucket)
+            case .exactCPU:
+                break
             }
         case .gpt2:
             _ = try ensureHybridCompiled(bucket: bucket)
@@ -6238,7 +6230,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             )
         }
 
-        if try Self.resolvedLlamaGenerationPath(
+        if try Self.resolvedTrunk(
             config: config,
             environment: ProcessInfo.processInfo.environment
         ) == .exactCPU {

--- a/Tests/ModelSupportTests/TrunkTests.swift
+++ b/Tests/ModelSupportTests/TrunkTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import ModelSupport
+
+@Test func trunkTelemetryLabelsMatchCONTEXTVocabulary() {
+    #expect(Trunk.fusedHybrid.rawValue == "fused")
+    #expect(Trunk.splitHybrid.rawValue == "hybrid")
+    #expect(Trunk.exactCPU.rawValue == "exact_cpu")
+    #expect(Trunk.fusedHybrid.isHybrid)
+    #expect(Trunk.splitHybrid.isHybrid)
+    #expect(!Trunk.exactCPU.isHybrid)
+}
+
+@Test func trunkParseTelemetryLabelTrimsAndLowercases() throws {
+    #expect(try Trunk.parseTelemetryLabel("fused") == .fusedHybrid)
+    #expect(try Trunk.parseTelemetryLabel(" HYBRID ") == .splitHybrid)
+    #expect(try Trunk.parseTelemetryLabel("Exact_CPU") == .exactCPU)
+    #expect(throws: Trunk.ParseError.unsupported("metal")) {
+        try Trunk.parseTelemetryLabel("metal")
+    }
+}
+
+@Test func preferredDecodePathMapsOntoTrunkFamilyOnly() {
+    #expect(MultiModelConfig.PreferredDecodePath.hybrid.prefersHybridFamily)
+    #expect(MultiModelConfig.PreferredDecodePath.hybrid.exactCPUTrunk == nil)
+    #expect(MultiModelConfig.PreferredDecodePath.exactCPU.exactCPUTrunk == .exactCPU)
+    #expect(!MultiModelConfig.PreferredDecodePath.exactCPU.prefersHybridFamily)
+}

--- a/Tests/RealModelInferenceTests/HybridLlamaDecodeStepTests.swift
+++ b/Tests/RealModelInferenceTests/HybridLlamaDecodeStepTests.swift
@@ -382,7 +382,9 @@ import ModelSupport
         ) == true
     )
     #expect(RealModelInferenceEngine.fusedHopsPerToken(nLayer: 28) == 28)
-    #expect(RealModelInferenceEngine.fusedDecodePathLabel == "fused")
+    #expect(RealModelInferenceEngine.fusedDecodePathLabel == Trunk.fusedHybrid.telemetryLabel)
+    #expect(RealModelInferenceEngine.selectTrunk(config: qwen15b, environment: [:]) == .fusedHybrid)
+    #expect(RealModelInferenceEngine.selectTrunk(config: qwen05b, environment: [:]) == .splitHybrid)
     let missing = RealModelInferenceEngine.fusedHybridFallbackError(reason: "missing N=1 kernel")
     guard case let .hybridFallbackDisabled(stage, reason) = missing else {
         Issue.record("expected hybridFallbackDisabled, got \(missing)")

--- a/Tests/RealModelInferenceTests/QwenParityExactMatchTests.swift
+++ b/Tests/RealModelInferenceTests/QwenParityExactMatchTests.swift
@@ -295,9 +295,11 @@ private func assertQwenGreedyFixtureCoversTheRequiredSuite(profile: QwenParityPr
         exactHeadBackend: "cpu_fp16_tiled",
         decodeProfileReport: "decode_profile_mean_ms/token qkv=1.00 rope=2.00 attn=3.00 ffn=4.00 lm_head=5.00 io=6.00 n=1 exclude_ttft=1"
     )
+    #expect(original.trunk == nil)
     #expect(original.decodePath == "unknown")
     #expect(original.hopsPerToken == nil)
-    let labeled = original.withDecodePath("hybrid")
+    let labeled = original.withTrunk(.splitHybrid)
+    #expect(labeled.trunk == .splitHybrid)
     #expect(labeled.decodePath == "hybrid")
     #expect(labeled.hopsPerToken == nil)
     #expect(labeled.tokens == original.tokens)
@@ -356,12 +358,13 @@ private func assertQwenGreedyParityMatchesPyTorchReferenceOnANE(
     let weightDir = bundle.archive.weightsURL.path
     #expect(config.preferredDecodePath == .hybrid)
     #expect(config.name == profile.displayName)
-    // With fallback disabled this artifact must resolve to the ANE hybrid path, never CPU.
+    // With fallback disabled this artifact must resolve to an ANE hybrid trunk, never CPU.
+    let expectedTrunk: Trunk = ModelFamily.isQwen15BVariant(config) ? .fusedHybrid : .splitHybrid
     #expect(
-        try RealModelInferenceEngine.resolvedLlamaGenerationPath(
+        try RealModelInferenceEngine.resolvedTrunk(
             config: config,
             environment: ["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK": "1"]
-        ) == .hybrid
+        ) == expectedTrunk
     )
 
     let cases = fixture.cases
@@ -388,11 +391,9 @@ private func assertQwenGreedyParityMatchesPyTorchReferenceOnANE(
         )
     }
     #expect(snapshots.count == cases.count + 2)
-    let expectedDecodePath = ModelFamily.isQwen15BVariant(config)
-        ? RealModelInferenceEngine.fusedDecodePathLabel
-        : "hybrid"
+    let expectedDecodePath = expectedTrunk.telemetryLabel
     #expect(snapshots.allSatisfy { $0.decodePath == expectedDecodePath })
-    if expectedDecodePath == RealModelInferenceEngine.fusedDecodePathLabel {
+    if expectedTrunk == .fusedHybrid {
         #expect(snapshots.allSatisfy { $0.hopsPerToken == 28 })
         #expect(snapshots.allSatisfy { $0.cachedBindingsEnabled == false })
         #expect(snapshots.allSatisfy { $0.exactHeadBackend == "cpu_fp16_tiled" })

--- a/Tests/RealModelInferenceTests/QwenParityExactMatchTests.swift
+++ b/Tests/RealModelInferenceTests/QwenParityExactMatchTests.swift
@@ -284,7 +284,7 @@ private func assertQwenGreedyFixtureCoversTheRequiredSuite(profile: QwenParityPr
     #expect(resolved15b?.rootURL.path != resolved05b?.rootURL.path)
 }
 
-@Test func test_generationResultWithDecodePathPreservesTokens() {
+@Test func test_generationResultWithDecodePathPreservesTokens() throws {
     let original = GenerationResult(
         text: "hi",
         tokens: [1, 2],
@@ -305,7 +305,7 @@ private func assertQwenGreedyFixtureCoversTheRequiredSuite(profile: QwenParityPr
     #expect(labeled.tokens == original.tokens)
     #expect(labeled.exactHeadBackend == "cpu_fp16_tiled")
     #expect(labeled.decodeProfileReport == original.decodeProfileReport)
-    let fused = GenerationResult(
+    let fused = try GenerationResult(
         text: "hi",
         tokens: [1],
         promptTokens: [9],
@@ -317,7 +317,18 @@ private func assertQwenGreedyFixtureCoversTheRequiredSuite(profile: QwenParityPr
         decodePath: "fused",
         hopsPerToken: 28
     )
-    #expect(fused.withDecodePath("fused").hopsPerToken == 28)
+    #expect(try fused.withDecodePath("fused").hopsPerToken == 28)
+    #expect(throws: Trunk.ParseError.unsupported("metal")) {
+        try GenerationResult(
+            text: "hi",
+            tokens: [1],
+            promptTokens: [9],
+            tokensPerSecond: 0,
+            compileTimeMs: 1,
+            firstTokenLatencyMs: 1,
+            decodePath: "metal"
+        )
+    }
 }
 
 /// Greedy decoding on the ANE hybrid path must reproduce the PyTorch reference token IDs.

--- a/Tests/RealModelInferenceTests/RealModelInferenceTests.swift
+++ b/Tests/RealModelInferenceTests/RealModelInferenceTests.swift
@@ -781,7 +781,7 @@ private func shouldRunLegacyQwenExperimentTests(
     )
 }
 
-@Test func test_llamaGenerationPath_skipsHybridForQwenExactCPU() {
+@Test func test_selectTrunk_skipsHybridForQwenExactCPU() {
     let qwenConfig = MultiModelConfig(
         name: "qwen3",
         nLayer: 1,
@@ -810,22 +810,22 @@ private func shouldRunLegacyQwenExperimentTests(
     )
 
     #expect(
-        RealModelInferenceEngine.llamaGenerationPath(
+        RealModelInferenceEngine.selectTrunk(
             config: qwenConfig,
             environment: [:]
         ) == .exactCPU
     )
     #expect(
-        RealModelInferenceEngine.llamaGenerationPath(
+        RealModelInferenceEngine.selectTrunk(
             config: qwenConfig,
             environment: ["ESPRESSO_FORCE_HYBRID_DECODE": "1"]
-        ) == .hybrid
+        ) == .splitHybrid
     )
     #expect(
-        RealModelInferenceEngine.llamaGenerationPath(
+        RealModelInferenceEngine.selectTrunk(
             config: llamaConfig,
             environment: [:]
-        ) == .hybrid
+        ) == .splitHybrid
     )
 }
 
@@ -853,26 +853,26 @@ private func makeDecodePathRoutingConfig(
     // A Qwen-named artifact that declares the hybrid path must reach the ANE, otherwise
     // "runs on the ANE" would silently mean "runs on the CPU".
     #expect(
-        RealModelInferenceEngine.llamaGenerationPath(
+        RealModelInferenceEngine.selectTrunk(
             config: makeDecodePathRoutingConfig(name: "Qwen2.5-0.5B-Instruct", preferredDecodePath: .hybrid),
             environment: [:]
-        ) == .hybrid
+        ) == .splitHybrid
     )
     #expect(
-        RealModelInferenceEngine.llamaGenerationPath(
+        RealModelInferenceEngine.selectTrunk(
             config: makeDecodePathRoutingConfig(name: "Qwen2.5-1.5B-Instruct", preferredDecodePath: .hybrid),
             environment: [:]
-        ) == .hybrid
+        ) == .fusedHybrid
     )
     #expect(
-        RealModelInferenceEngine.llamaGenerationPath(
+        RealModelInferenceEngine.selectTrunk(
             config: makeDecodePathRoutingConfig(name: "llama3", preferredDecodePath: .exactCPU),
             environment: [:]
         ) == .exactCPU
     )
     // An artifact declaring hybrid still yields to an explicit operator override.
     #expect(
-        RealModelInferenceEngine.llamaGenerationPath(
+        RealModelInferenceEngine.selectTrunk(
             config: makeDecodePathRoutingConfig(name: "Qwen2.5-0.5B-Instruct", preferredDecodePath: .hybrid),
             environment: ["ESPRESSO_USE_CPU_EXACT_DECODE": "1"]
         ) == .exactCPU
@@ -917,12 +917,12 @@ private func makeDecodePathRoutingConfig(
     }
 }
 
-@Test func test_resolvedLlamaGenerationPathThrowsWhenFallbackDisabledWouldLeaveANE() throws {
+@Test func test_resolvedTrunkThrowsWhenFallbackDisabledWouldLeaveANE() throws {
     let disabled = ["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK": "1"]
 
     // Legacy name-based CPU routing must be loud, naming the policy responsible.
     do {
-        _ = try RealModelInferenceEngine.resolvedLlamaGenerationPath(
+        _ = try RealModelInferenceEngine.resolvedTrunk(
             config: makeDecodePathRoutingConfig(name: "Qwen2.5-0.5B-Instruct"),
             environment: disabled
         )
@@ -932,13 +932,13 @@ private func makeDecodePathRoutingConfig(
             Issue.record("expected hybridFallbackDisabled, got \(error)")
             return
         }
-        #expect(stage.contains("decode path"))
+        #expect(stage.contains("trunk"))
         #expect(reason.contains("legacy Qwen"))
     }
 
     // An explicit CPU request must also be loud rather than quietly honoured.
     do {
-        _ = try RealModelInferenceEngine.resolvedLlamaGenerationPath(
+        _ = try RealModelInferenceEngine.resolvedTrunk(
             config: makeDecodePathRoutingConfig(name: "llama3"),
             environment: disabled.merging(["ESPRESSO_USE_CPU_EXACT_DECODE": "1"]) { current, _ in current }
         )
@@ -953,7 +953,7 @@ private func makeDecodePathRoutingConfig(
 
     // An artifact that declares exact_cpu is still a fallback when the flag forbids one.
     do {
-        _ = try RealModelInferenceEngine.resolvedLlamaGenerationPath(
+        _ = try RealModelInferenceEngine.resolvedTrunk(
             config: makeDecodePathRoutingConfig(name: "llama3", preferredDecodePath: .exactCPU),
             environment: disabled
         )
@@ -966,12 +966,12 @@ private func makeDecodePathRoutingConfig(
         #expect(reason.contains("preferredDecodePath"))
     }
 
-    // The hybrid path is unaffected by the flag.
+    // Hybrid trunks are unaffected by the flag.
     #expect(
-        try RealModelInferenceEngine.resolvedLlamaGenerationPath(
+        try RealModelInferenceEngine.resolvedTrunk(
             config: makeDecodePathRoutingConfig(name: "Qwen2.5-0.5B-Instruct", preferredDecodePath: .hybrid),
             environment: disabled
-        ) == .hybrid
+        ) == .splitHybrid
     )
 }
 


### PR DESCRIPTION
## Summary
- Add closed `Trunk` (`fusedHybrid` / `splitHybrid` / `exactCPU`) matching `CONTEXT.md`, with stable telemetry labels `fused` / `hybrid` / `exact_cpu`
- Make `GenerationResult.trunk` the source of truth; keep `decodePath` as a computed compatibility label for CLI/JSON
- Resolve serving via `selectTrunk` / `resolvedTrunk` instead of `LlamaGenerationPath` + `prefersFusedHybridDecode` bool pairing; leave `PreferredDecodePath` as the artifact wire format only

## Test plan
- [x] `swift test --filter 'TrunkTests|test_selectTrunk|test_preferredDecodePathOverrides|test_resolvedTrunkThrows|test_prefersFusedHybridDecode|test_generationResultWithDecodePath|preferredDecodePathParse'`
- [x] `swift test --filter 'EspressoGenerateTests|ModelSupportTests|ESPCompilerSupportTests'` (126 passed)
- [ ] Spot-check `espresso-generate` / chat still emits `decode_path=hybrid|fused` as before


Made with [Cursor](https://cursor.com)