### PR TITLE
Unify top-level weight loading behind TopLevelAssetLoader

### DIFF
--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -606,44 +606,6 @@ public struct RealModelInferenceEngine: ~Copyable {
         let lmHead: String
     }
 
-    private struct GPT2TopLevelAssets {
-        let tokenEmbedding: [Float]
-        let positionEmbedding: [Float]
-        let finalNormGamma: [Float]
-        let finalNormBeta: [Float]
-        let lmHead: [Float]
-        let finalNormGammaPath: String
-        let finalNormBetaPath: String
-        let finalNormGammaCompilePath: String
-        let finalNormBetaCompilePath: String
-        let finalNormGammaData: Data
-        let finalNormBetaData: Data
-    }
-
-    private struct LlamaTopLevelAssets {
-        struct FactoredOutputHead: Sendable, Equatable {
-            let projection: [Float]
-            let expansion: [Float]
-            let bottleneck: Int
-            let groups: Int
-        }
-
-        let tokenEmbedding: [Float]
-        let finalNormGamma: [Float]
-        let lmHead: [Float]
-        let lmHeadFP16: [UInt16]?
-        let lmHeadHasExactFloat32Sidecar: Bool
-        let factoredOutputHead: FactoredOutputHead?
-        let finalNormGammaPath: String
-        let finalNormGammaCompilePath: String
-        let finalNormGammaData: Data
-    }
-
-    private enum TopLevelAssets {
-        case gpt2(GPT2TopLevelAssets)
-        case llama(LlamaTopLevelAssets)
-    }
-
     struct AttentionTestingOutputs {
         let hidden: [Float]
         let kCache: [Float]
@@ -804,18 +766,13 @@ public struct RealModelInferenceEngine: ~Copyable {
             )
             self.config = config
             self.roundIntermediatesToFP16 = RealModelInferenceEngine.shouldRoundCPUExactDecodeIntermediatesToFP16()
-            self.tokenEmbedding = try RealModelInferenceEngine.loadWeightTablePreferringFloat32Sidecar(
-                at: topLevelPaths.tokenEmbedding,
-                expectedCount: config.vocab * config.dModel
+            let coreWeights = try TopLevelAssetLoader.loadLlamaCoreWeights(
+                config: config,
+                topLevelPaths: topLevelPaths
             )
-            self.finalNormGamma = try RealModelInferenceEngine.loadWeightTablePreferringFloat32Sidecar(
-                at: topLevelPaths.finalNormGamma,
-                expectedCount: config.dModel
-            )
-            self.lmHead = try RealModelInferenceEngine.loadWeightTablePreferringFloat32Sidecar(
-                at: topLevelPaths.lmHead,
-                expectedCount: config.vocab * config.dModel
-            )
+            self.tokenEmbedding = coreWeights.tokenEmbedding
+            self.finalNormGamma = coreWeights.finalNormGamma
+            self.lmHead = coreWeights.lmHead
             self.layers = try (0..<config.nLayer).map { layerIndex in
                 let paths = LayerWeightPaths.forLayer(
                     layerIndex,
@@ -1636,7 +1593,7 @@ public struct RealModelInferenceEngine: ~Copyable {
 
         let tokenizer = try loadTokenizer(config: config, tokenizerDirURL: tokenizerDirURL)
 
-        let topLevelAssets = try loadTestingTopLevelAssets(
+        let topLevelAssets = try TopLevelAssetLoader.load(
             config: config,
             weightDir: weightDir,
             weightDirURL: weightDirURL
@@ -2088,51 +2045,11 @@ public struct RealModelInferenceEngine: ~Copyable {
         try validateDirectory(weightDirURL)
         try validateMetadataIfPresent(config: config, weightDirURL: weightDirURL)
 
-        let topLevelAssets: TopLevelAssets
-        switch config.architecture {
-        case .gpt2:
-            let topLevelPaths = try resolveTopLevelWeightPaths(config: config, weightDir: weightDir)
-            let tokenEmbedding = try loadWeightTablePreferringFloat32Sidecar(
-                at: topLevelPaths.tokenEmbedding,
-                expectedCount: config.vocab * config.dModel
-            )
-            let positionEmbedding = try loadWeightTable(
-                at: topLevelPaths.positionEmbedding,
-                expectedCount: config.maxSeq * config.dModel
-            )
-            let finalNormGamma = try loadWeightTablePreferringFloat32Sidecar(
-                at: topLevelPaths.finalNormGamma,
-                expectedCount: config.dModel
-            )
-            let finalNormBeta = try loadWeightTable(
-                at: topLevelPaths.finalNormBeta,
-                expectedCount: config.dModel
-            )
-            let lmHead = try loadWeightTablePreferringFloat32Sidecar(
-                at: topLevelPaths.lmHead,
-                expectedCount: config.vocab * config.dModel
-            )
-            topLevelAssets = .gpt2(GPT2TopLevelAssets(
-                tokenEmbedding: tokenEmbedding,
-                positionEmbedding: positionEmbedding,
-                finalNormGamma: finalNormGamma,
-                finalNormBeta: finalNormBeta,
-                lmHead: lmHead,
-                finalNormGammaPath: topLevelPaths.finalNormGamma,
-                finalNormBetaPath: topLevelPaths.finalNormBeta,
-                finalNormGammaCompilePath: compileBlobPath(actualPath: topLevelPaths.finalNormGamma, rootDir: weightDirURL),
-                finalNormBetaCompilePath: compileBlobPath(actualPath: topLevelPaths.finalNormBeta, rootDir: weightDirURL),
-                finalNormGammaData: WeightBlob.build(from: finalNormGamma, rows: 1, cols: finalNormGamma.count),
-                finalNormBetaData: WeightBlob.build(from: finalNormBeta, rows: 1, cols: finalNormBeta.count)
-            ))
-        case .llama:
-            let topLevelPaths = try resolveLlamaTopLevelWeightPaths(config: config, weightDir: weightDir)
-            topLevelAssets = .llama(try loadLlamaTopLevelAssets(
-                config: config,
-                topLevelPaths: topLevelPaths,
-                weightDirURL: weightDirURL
-            ))
-        }
+        let topLevelAssets = try TopLevelAssetLoader.load(
+            config: config,
+            weightDir: weightDir,
+            weightDirURL: weightDirURL
+        )
 
         var engine = RealModelInferenceEngine(
             config: config,
@@ -2273,7 +2190,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         try validateDirectory(weightDirURL)
         try validateMetadataIfPresent(config: config, weightDirURL: weightDirURL)
 
-        let topLevelAssets = try loadTestingTopLevelAssets(
+        let topLevelAssets = try TopLevelAssetLoader.load(
             config: config,
             weightDir: weightDir,
             weightDirURL: weightDirURL
@@ -2316,7 +2233,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         try validateDirectory(weightDirURL)
         try validateMetadataIfPresent(config: config, weightDirURL: weightDirURL)
 
-        let topLevelAssets = try loadTestingTopLevelAssets(
+        let topLevelAssets = try TopLevelAssetLoader.load(
             config: config,
             weightDir: weightDir,
             weightDirURL: weightDirURL
@@ -2336,152 +2253,6 @@ public struct RealModelInferenceEngine: ~Copyable {
             onStep: nil
         )
         return result.tokens
-    }
-
-    private static func loadTestingTopLevelAssets(
-        config: MultiModelConfig,
-        weightDir: String,
-        weightDirURL: URL
-    ) throws -> TopLevelAssets {
-        switch config.architecture {
-        case .gpt2:
-            let topLevelPaths = try resolveTopLevelWeightPaths(config: config, weightDir: weightDir)
-            let tokenEmbedding = try loadWeightTablePreferringFloat32Sidecar(
-                at: topLevelPaths.tokenEmbedding,
-                expectedCount: config.vocab * config.dModel
-            )
-            let positionEmbedding = try loadWeightTable(
-                at: topLevelPaths.positionEmbedding,
-                expectedCount: config.maxSeq * config.dModel
-            )
-            let finalNormGamma = try loadWeightTablePreferringFloat32Sidecar(
-                at: topLevelPaths.finalNormGamma,
-                expectedCount: config.dModel
-            )
-            let finalNormBeta = try loadWeightTable(
-                at: topLevelPaths.finalNormBeta,
-                expectedCount: config.dModel
-            )
-            let lmHead = try loadWeightTablePreferringFloat32Sidecar(
-                at: topLevelPaths.lmHead,
-                expectedCount: config.vocab * config.dModel
-            )
-            return .gpt2(GPT2TopLevelAssets(
-                tokenEmbedding: tokenEmbedding,
-                positionEmbedding: positionEmbedding,
-                finalNormGamma: finalNormGamma,
-                finalNormBeta: finalNormBeta,
-                lmHead: lmHead,
-                finalNormGammaPath: topLevelPaths.finalNormGamma,
-                finalNormBetaPath: topLevelPaths.finalNormBeta,
-                finalNormGammaCompilePath: compileBlobPath(actualPath: topLevelPaths.finalNormGamma, rootDir: weightDirURL),
-                finalNormBetaCompilePath: compileBlobPath(actualPath: topLevelPaths.finalNormBeta, rootDir: weightDirURL),
-                finalNormGammaData: WeightBlob.build(from: finalNormGamma, rows: 1, cols: finalNormGamma.count),
-                finalNormBetaData: WeightBlob.build(from: finalNormBeta, rows: 1, cols: finalNormBeta.count)
-            ))
-        case .llama:
-            let topLevelPaths = try resolveLlamaTopLevelWeightPaths(config: config, weightDir: weightDir)
-            return .llama(try loadLlamaTopLevelAssets(
-                config: config,
-                topLevelPaths: topLevelPaths,
-                weightDirURL: weightDirURL
-            ))
-        }
-    }
-
-    private static func loadLlamaTopLevelAssets(
-        config: MultiModelConfig,
-        topLevelPaths: LlamaTopLevelWeightPaths,
-        weightDirURL: URL,
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) throws -> LlamaTopLevelAssets {
-        let tokenEmbedding = try loadWeightTablePreferringFloat32Sidecar(
-            at: topLevelPaths.tokenEmbedding,
-            expectedCount: config.vocab * config.dModel
-        )
-        let finalNormGamma = try loadWeightTablePreferringFloat32Sidecar(
-            at: topLevelPaths.finalNormGamma,
-            expectedCount: config.dModel
-        )
-        let lmHead = try loadWeightTablePreferringFloat32Sidecar(
-            at: topLevelPaths.lmHead,
-            expectedCount: config.vocab * config.dModel
-        )
-        let lmHeadFP16 = try loadRawFP16WeightTableIfNoExactFloat32Sidecar(
-            at: topLevelPaths.lmHead,
-            expectedCount: config.vocab * config.dModel
-        )
-        let factoredOutputHead = try loadLlamaFactoredOutputHead(
-            config: config,
-            weightDirURL: weightDirURL,
-            environment: environment
-        )
-        return LlamaTopLevelAssets(
-            tokenEmbedding: tokenEmbedding,
-            finalNormGamma: finalNormGamma,
-            lmHead: lmHead,
-            lmHeadFP16: lmHeadFP16,
-            lmHeadHasExactFloat32Sidecar: lmHeadFP16 == nil,
-            factoredOutputHead: factoredOutputHead,
-            finalNormGammaPath: topLevelPaths.finalNormGamma,
-            finalNormGammaCompilePath: compileBlobPath(actualPath: topLevelPaths.finalNormGamma, rootDir: weightDirURL),
-            finalNormGammaData: WeightBlob.build(from: finalNormGamma, rows: 1, cols: finalNormGamma.count)
-        )
-    }
-
-    private static func loadLlamaFactoredOutputHead(
-        config: MultiModelConfig,
-        weightDirURL: URL,
-        environment: [String: String]
-    ) throws -> LlamaTopLevelAssets.FactoredOutputHead? {
-        guard config.architecture == .llama,
-              environment["ESPRESSO_BUNDLE_OUTPUT_HEAD_KIND"] == "factored" else {
-            return nil
-        }
-
-        guard let bottleneckRaw = environment["ESPRESSO_BUNDLE_OUTPUT_HEAD_BOTTLENECK"],
-              let bottleneck = Int(bottleneckRaw),
-              bottleneck > 0 else {
-            throw RealModelInferenceError.invalidConfig(
-                "Factored output head requires ESPRESSO_BUNDLE_OUTPUT_HEAD_BOTTLENECK > 0"
-            )
-        }
-        guard let groupsRaw = environment["ESPRESSO_BUNDLE_OUTPUT_HEAD_GROUPS"],
-              let groups = Int(groupsRaw),
-              groups > 0 else {
-            throw RealModelInferenceError.invalidConfig(
-                "Factored output head requires ESPRESSO_BUNDLE_OUTPUT_HEAD_GROUPS > 0"
-            )
-        }
-
-        let projectionPath = try resolveBundleWeightReference(
-            environment["ESPRESSO_BUNDLE_OUTPUT_HEAD_PROJECTION_REF"] ?? "cls_proj.bin",
-            weightDirURL: weightDirURL
-        )
-        let expansionPath = try resolveBundleWeightReference(
-            environment["ESPRESSO_BUNDLE_OUTPUT_HEAD_EXPANSION_REF"] ?? "cls_expand.bin",
-            weightDirURL: weightDirURL
-        )
-
-        let projectionCompactCount = bottleneck * (config.dModel / groups)
-        let projectionDenseCount = bottleneck * config.dModel
-        let expansionCompactCount = config.vocab * (bottleneck / groups)
-        let expansionDenseCount = config.vocab * bottleneck
-        let projection = try loadWeightTable(
-            at: projectionPath,
-            allowedCounts: [projectionCompactCount, projectionDenseCount]
-        )
-        let expansion = try loadWeightTable(
-            at: expansionPath,
-            allowedCounts: [expansionCompactCount, expansionDenseCount]
-        )
-
-        return LlamaTopLevelAssets.FactoredOutputHead(
-            projection: projection,
-            expansion: expansion,
-            bottleneck: bottleneck,
-            groups: groups
-        )
     }
 
     static func spatialBucket(for tokenCount: Int, maxSeq: Int) -> Int {
@@ -6739,17 +6510,9 @@ public struct RealModelInferenceEngine: ~Copyable {
             config: config,
             weightDir: weightDirURL.path
         )
-        let tokenEmbedding = try Self.loadWeightTablePreferringFloat32Sidecar(
-            at: topLevelPaths.tokenEmbedding,
-            expectedCount: config.vocab * config.dModel
-        )
-        let finalNormGamma = try Self.loadWeightTablePreferringFloat32Sidecar(
-            at: topLevelPaths.finalNormGamma,
-            expectedCount: config.dModel
-        )
-        let lmHead = try Self.loadWeightTablePreferringFloat32Sidecar(
-            at: topLevelPaths.lmHead,
-            expectedCount: config.vocab * config.dModel
+        let coreWeights = try TopLevelAssetLoader.loadLlamaCoreWeights(
+            config: config,
+            topLevelPaths: topLevelPaths
         )
         let lmHeadFP16 = try Self.loadRawFP16WeightTableIfNoExactFloat32Sidecar(
             at: topLevelPaths.lmHead,
@@ -6764,9 +6527,9 @@ public struct RealModelInferenceEngine: ~Copyable {
             return try Self.loadExactCPULlamaLayerWeights(config: config, paths: paths)
         }
         let loadedWeights = CachedExactCPULlamaWeights(
-            tokenEmbedding: tokenEmbedding,
-            finalNormGamma: finalNormGamma,
-            lmHead: lmHead,
+            tokenEmbedding: coreWeights.tokenEmbedding,
+            finalNormGamma: coreWeights.finalNormGamma,
+            lmHead: coreWeights.lmHead,
             lmHeadFP16: lmHeadFP16,
             layers: layers
         )
@@ -8818,7 +8581,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         return FileManager.default.fileExists(atPath: path)
     }
 
-    private static func resolveBundleWeightReference(
+    static func resolveBundleWeightReference(
         _ reference: String,
         weightDirURL: URL
     ) throws -> String {
@@ -8836,7 +8599,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         return resolved
     }
 
-    private static func compileBlobPath(actualPath: String, rootDir: URL) -> String {
+    static func compileBlobPath(actualPath: String, rootDir: URL) -> String {
         let rootPath = rootDir.standardizedFileURL.path
         let filePath = URL(fileURLWithPath: actualPath).standardizedFileURL.path
         let relativePath: String

--- a/Sources/RealModelInference/TopLevelAssetLoader.swift
+++ b/Sources/RealModelInference/TopLevelAssetLoader.swift
@@ -1,0 +1,222 @@
+import Foundation
+import ANERuntime
+import ANETypes
+import ModelSupport
+
+/// Top-level weight artifacts shared by every serving trunk: token embedding,
+/// final norm, and LM head.
+///
+/// One module, one interface (`TopLevelAssetLoader.load`). Callers never touch
+/// weight paths or sidecar rules directly; fixing a loading rule happens here
+/// once and holds for GPT-2 dispatch, llama serving, and exact-CPU alike.
+struct GPT2TopLevelAssets {
+    let tokenEmbedding: [Float]
+    let positionEmbedding: [Float]
+    let finalNormGamma: [Float]
+    let finalNormBeta: [Float]
+    let lmHead: [Float]
+    let finalNormGammaPath: String
+    let finalNormBetaPath: String
+    let finalNormGammaCompilePath: String
+    let finalNormBetaCompilePath: String
+    let finalNormGammaData: Data
+    let finalNormBetaData: Data
+}
+
+struct LlamaTopLevelAssets {
+    struct FactoredOutputHead: Sendable, Equatable {
+        let projection: [Float]
+        let expansion: [Float]
+        let bottleneck: Int
+        let groups: Int
+    }
+
+    let tokenEmbedding: [Float]
+    let finalNormGamma: [Float]
+    let lmHead: [Float]
+    let lmHeadFP16: [UInt16]?
+    let lmHeadHasExactFloat32Sidecar: Bool
+    let factoredOutputHead: FactoredOutputHead?
+    let finalNormGammaPath: String
+    let finalNormGammaCompilePath: String
+    let finalNormGammaData: Data
+}
+
+enum TopLevelAssets {
+    case gpt2(GPT2TopLevelAssets)
+    case llama(LlamaTopLevelAssets)
+}
+
+/// The llama top-level triple every consumer needs; `lmHeadFP16` is loaded
+/// separately by consumers that actually run the fp16 head.
+struct LlamaCoreWeights {
+    let tokenEmbedding: [Float]
+    let finalNormGamma: [Float]
+    let lmHead: [Float]
+}
+
+/// Single production load path for an engine's top-level weights.
+///
+/// Historically this lived on the engine as `loadTestingTopLevelAssets` — a
+/// misleading name for code that backs `RealModelInferenceEngine.build`.
+enum TopLevelAssetLoader {
+    static func load(
+        config: MultiModelConfig,
+        weightDir: String,
+        weightDirURL: URL,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> TopLevelAssets {
+        switch config.architecture {
+        case .gpt2:
+            let topLevelPaths = try RealModelInferenceEngine.resolveTopLevelWeightPaths(config: config, weightDir: weightDir)
+            let tokenEmbedding = try RealModelInferenceEngine.loadWeightTablePreferringFloat32Sidecar(
+                at: topLevelPaths.tokenEmbedding,
+                expectedCount: config.vocab * config.dModel
+            )
+            let positionEmbedding = try RealModelInferenceEngine.loadWeightTable(
+                at: topLevelPaths.positionEmbedding,
+                expectedCount: config.maxSeq * config.dModel
+            )
+            let finalNormGamma = try RealModelInferenceEngine.loadWeightTablePreferringFloat32Sidecar(
+                at: topLevelPaths.finalNormGamma,
+                expectedCount: config.dModel
+            )
+            let finalNormBeta = try RealModelInferenceEngine.loadWeightTable(
+                at: topLevelPaths.finalNormBeta,
+                expectedCount: config.dModel
+            )
+            let lmHead = try RealModelInferenceEngine.loadWeightTablePreferringFloat32Sidecar(
+                at: topLevelPaths.lmHead,
+                expectedCount: config.vocab * config.dModel
+            )
+            return .gpt2(GPT2TopLevelAssets(
+                tokenEmbedding: tokenEmbedding,
+                positionEmbedding: positionEmbedding,
+                finalNormGamma: finalNormGamma,
+                finalNormBeta: finalNormBeta,
+                lmHead: lmHead,
+                finalNormGammaPath: topLevelPaths.finalNormGamma,
+                finalNormBetaPath: topLevelPaths.finalNormBeta,
+                finalNormGammaCompilePath: RealModelInferenceEngine.compileBlobPath(actualPath: topLevelPaths.finalNormGamma, rootDir: weightDirURL),
+                finalNormBetaCompilePath: RealModelInferenceEngine.compileBlobPath(actualPath: topLevelPaths.finalNormBeta, rootDir: weightDirURL),
+                finalNormGammaData: WeightBlob.build(from: finalNormGamma, rows: 1, cols: finalNormGamma.count),
+                finalNormBetaData: WeightBlob.build(from: finalNormBeta, rows: 1, cols: finalNormBeta.count)
+            ))
+        case .llama:
+            let topLevelPaths = try RealModelInferenceEngine.resolveLlamaTopLevelWeightPaths(config: config, weightDir: weightDir)
+            return .llama(try loadLlamaTopLevelAssets(
+                config: config,
+                topLevelPaths: topLevelPaths,
+                weightDirURL: weightDirURL,
+                environment: environment
+            ))
+        }
+    }
+
+    /// The llama triple (token embedding, final-norm gamma, exact-float32 LM
+    /// head) shared by full asset loads, the CPU-exact runtime, and the
+    /// lazily-cached exact-CPU weights.
+    static func loadLlamaCoreWeights(
+        config: MultiModelConfig,
+        topLevelPaths: RealModelInferenceEngine.LlamaTopLevelWeightPaths
+    ) throws -> LlamaCoreWeights {
+        LlamaCoreWeights(
+            tokenEmbedding: try RealModelInferenceEngine.loadWeightTablePreferringFloat32Sidecar(
+                at: topLevelPaths.tokenEmbedding,
+                expectedCount: config.vocab * config.dModel
+            ),
+            finalNormGamma: try RealModelInferenceEngine.loadWeightTablePreferringFloat32Sidecar(
+                at: topLevelPaths.finalNormGamma,
+                expectedCount: config.dModel
+            ),
+            lmHead: try RealModelInferenceEngine.loadWeightTablePreferringFloat32Sidecar(
+                at: topLevelPaths.lmHead,
+                expectedCount: config.vocab * config.dModel
+            )
+        )
+    }
+
+    static func loadLlamaTopLevelAssets(
+        config: MultiModelConfig,
+        topLevelPaths: RealModelInferenceEngine.LlamaTopLevelWeightPaths,
+        weightDirURL: URL,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> LlamaTopLevelAssets {
+        let core = try loadLlamaCoreWeights(config: config, topLevelPaths: topLevelPaths)
+        let lmHeadFP16 = try RealModelInferenceEngine.loadRawFP16WeightTableIfNoExactFloat32Sidecar(
+            at: topLevelPaths.lmHead,
+            expectedCount: config.vocab * config.dModel
+        )
+        let factoredOutputHead = try loadLlamaFactoredOutputHead(
+            config: config,
+            weightDirURL: weightDirURL,
+            environment: environment
+        )
+        return LlamaTopLevelAssets(
+            tokenEmbedding: core.tokenEmbedding,
+            finalNormGamma: core.finalNormGamma,
+            lmHead: core.lmHead,
+            lmHeadFP16: lmHeadFP16,
+            lmHeadHasExactFloat32Sidecar: lmHeadFP16 == nil,
+            factoredOutputHead: factoredOutputHead,
+            finalNormGammaPath: topLevelPaths.finalNormGamma,
+            finalNormGammaCompilePath: RealModelInferenceEngine.compileBlobPath(actualPath: topLevelPaths.finalNormGamma, rootDir: weightDirURL),
+            finalNormGammaData: WeightBlob.build(from: core.finalNormGamma, rows: 1, cols: core.finalNormGamma.count)
+        )
+    }
+
+    private static func loadLlamaFactoredOutputHead(
+        config: MultiModelConfig,
+        weightDirURL: URL,
+        environment: [String: String]
+    ) throws -> LlamaTopLevelAssets.FactoredOutputHead? {
+        guard config.architecture == .llama,
+              environment["ESPRESSO_BUNDLE_OUTPUT_HEAD_KIND"] == "factored" else {
+            return nil
+        }
+
+        guard let bottleneckRaw = environment["ESPRESSO_BUNDLE_OUTPUT_HEAD_BOTTLENECK"],
+              let bottleneck = Int(bottleneckRaw),
+              bottleneck > 0 else {
+            throw RealModelInferenceError.invalidConfig(
+                "Factored output head requires ESPRESSO_BUNDLE_OUTPUT_HEAD_BOTTLENECK > 0"
+            )
+        }
+        guard let groupsRaw = environment["ESPRESSO_BUNDLE_OUTPUT_HEAD_GROUPS"],
+              let groups = Int(groupsRaw),
+              groups > 0 else {
+            throw RealModelInferenceError.invalidConfig(
+                "Factored output head requires ESPRESSO_BUNDLE_OUTPUT_HEAD_GROUPS > 0"
+            )
+        }
+
+        let projectionPath = try RealModelInferenceEngine.resolveBundleWeightReference(
+            environment["ESPRESSO_BUNDLE_OUTPUT_HEAD_PROJECTION_REF"] ?? "cls_proj.bin",
+            weightDirURL: weightDirURL
+        )
+        let expansionPath = try RealModelInferenceEngine.resolveBundleWeightReference(
+            environment["ESPRESSO_BUNDLE_OUTPUT_HEAD_EXPANSION_REF"] ?? "cls_expand.bin",
+            weightDirURL: weightDirURL
+        )
+
+        let projectionCompactCount = bottleneck * (config.dModel / groups)
+        let projectionDenseCount = bottleneck * config.dModel
+        let expansionCompactCount = config.vocab * (bottleneck / groups)
+        let expansionDenseCount = config.vocab * bottleneck
+        let projection = try RealModelInferenceEngine.loadWeightTable(
+            at: projectionPath,
+            allowedCounts: [projectionCompactCount, projectionDenseCount]
+        )
+        let expansion = try RealModelInferenceEngine.loadWeightTable(
+            at: expansionPath,
+            allowedCounts: [expansionCompactCount, expansionDenseCount]
+        )
+
+        return LlamaTopLevelAssets.FactoredOutputHead(
+            projection: projection,
+            expansion: expansion,
+            bottleneck: bottleneck,
+            groups: groups
+        )
+    }
+}


### PR DESCRIPTION
## What

Collapses four independent top-level weight loaders into one module, `TopLevelAssetLoader` (`Sources/RealModelInference/TopLevelAssetLoader.swift`), with a single interface: `load(config:weightDir:weightDirURL:) -> TopLevelAssets`.

| Before | After |
|---|---|
| `loadTestingTopLevelAssets` (misnamed — production, called by `build()`) | `TopLevelAssetLoader.load` |
| Verbatim GPT-2 load switch inside `generateFromTokenSuiteForTesting` | calls the loader |
| `CPUExactLlamaRuntime.init` re-typing the llama triple | `loadLlamaCoreWeights` |
| `loadCachedExactCPULlamaWeights` re-typing the triple + fp16 head | `loadLlamaCoreWeights` + existing primitive |

The asset structs (`GPT2TopLevelAssets`, `LlamaTopLevelAssets`, `TopLevelAssets`) move from private engine nesting to internal module scope so the loader module can own them.

## Why

- **Locality:** a loading-rule change (sidecar preference, path layout) now lands in one file instead of up to four.
- **Navigability:** the question "who loads weights?" has one true answer; `loadTestingTopLevelAssets` previously sent readers down a testing-only path that was actually the production load path.
- **Behavior preserved:** `lmHeadFP16` stays a separate load so CPU-exact consumers that never touch it keep their memory profile. No call-site behavior changes.

## Verification

- `swift build` green
- `swift test`: 540 executed, 0 failures (169 hardware-gated tests skip without `ANE_HARDWARE_TESTS=1`)
- Weight-loader unit tests (sidecar preference, raw-fp16 fallback) pass unchanged
