### PR TITLE
Move hybrid decode surface bindings into ANERuntime

### DIFF
--- a/Sources/ANERuntime/HybridDecodeKernelSet.swift
+++ b/Sources/ANERuntime/HybridDecodeKernelSet.swift
@@ -63,6 +63,22 @@ public struct HybridDecodeKernelSet: ~Copyable {
     public let laneSpatial: Int
     package let donorHexIDs: DonorHexIDs
 
+    /// Runs the post-attention stage for one decode step: projection+FFN as a
+    /// single fused kernel when fusion compiled, otherwise projection then FFN.
+    /// Consumers eval stages through here instead of branching on fusion.
+    @inline(__always)
+    public func evalPostAttention() throws(ANEError) {
+        try decodeProjection.eval()
+        if !usesFusedPostAttention {
+            try decodeFFN.eval()
+        }
+    }
+
+    /// Stage label for diagnostics naming which post-attention shape ran.
+    public var postAttentionStageName: String {
+        usesFusedPostAttention ? "decodeProjectionFFN" : "decodeProjection+decodeFFN"
+    }
+
     @inline(__always)
     private static func buildBlob(from buffer: borrowing TensorBuffer, rows: Int, cols: Int) -> Data {
         buffer.withUnsafeBufferPointer { ptr in

--- a/Sources/ANERuntime/HybridDecodeSurfaceBindings.swift
+++ b/Sources/ANERuntime/HybridDecodeSurfaceBindings.swift
@@ -1,0 +1,166 @@
+import Foundation
+import IOSurface
+import ANEInterop
+import ANETypes
+
+/// Bridges untyped `rethrows` boundaries (`withUnsafeBufferPointer` and friends)
+/// into `throws(ANEError)` contexts. The stdlib buffer accessors erase typed
+/// throws to `any Error`, so SurfaceIO failures must be re-mapped at the boundary.
+@inline(__always)
+public func mapSurfaceIOToANEError<R>(_ body: () throws -> R) throws(ANEError) -> R {
+    do {
+        return try body()
+    } catch let error as SurfaceIOError {
+        throw .surfaceIO(error)
+    } catch let error as ANEError {
+        throw error
+    } catch {
+        throw .surfaceIO(.interopCallFailed)
+    }
+}
+
+/// Decode surfaces for the split hybrid path:
+/// ANE QKV-only -> Metal attention/projection -> ANE FFN.
+///
+/// Supports GQA: K/V caches use `kvDim` (nKVHeads * headDim) which may differ from `dim`.
+///
+/// The binding knowledge here — which kernel owns which surface index, how the
+/// projection/FFN kernels chain onto QKV outputs, fp16 cache sizing — belongs
+/// beside `HybridDecodeKernelSet`, not in its consumers.
+public struct HybridDecodeSurfaceHandles {
+    public let qkvIn: IOSurfaceRef
+    public let qOut: IOSurfaceRef
+    public let kOut: IOSurfaceRef
+    public let vOut: IOSurfaceRef
+    public let projectionContextIn: IOSurfaceRef
+    public let projectionResidualIn: IOSurfaceRef
+    public let projectionOut: IOSurfaceRef
+    public let ffnIn: IOSurfaceRef
+    public let ffnOut: IOSurfaceRef
+    public let kCacheFull: IOSurfaceRef
+    public let vCacheFull: IOSurfaceRef
+    public let zeroLane: IOSurfaceRef
+    public let maxSeq: Int
+    public let laneSpatial: Int
+
+    public let dim: Int
+    public let qDim: Int
+    public let kvDim: Int
+
+    public init(
+        kernels: borrowing HybridDecodeKernelSet,
+        logicalMaxSeq: Int? = nil,
+        dim: Int = ModelConfig.dim,
+        qDim: Int? = nil,
+        kvDim: Int? = nil
+    ) throws(ANEError) {
+        let resolvedQDim = qDim ?? dim
+        let resolvedKVDim = kvDim ?? dim
+        let qkvIn = try kernels.decodeQKVOnly.inputSurface(at: 0)
+        let kOut = try kernels.decodeQKVOnly.outputSurface(at: 0)
+        let qOut = try kernels.decodeQKVOnly.outputSurface(at: 1)
+        let vOut = try kernels.decodeQKVOnly.outputSurface(at: 2)
+        let projectionContextIn = try kernels.decodeProjection.inputSurface(at: 0)
+        let projectionOut = try kernels.decodeProjection.outputSurface(at: 0)
+        let ffnOut = try (kernels.usesFusedPostAttention
+            ? kernels.decodeProjection.outputSurface(at: 0)
+            : kernels.decodeFFN.outputSurface(at: 0))
+        try kernels.decodeProjection.rebindInput(at: 1, to: qkvIn)
+        if !kernels.usesFusedPostAttention {
+            try kernels.decodeFFN.rebindInput(at: 0, to: projectionOut)
+        }
+
+        self.dim = dim
+        self.qDim = resolvedQDim
+        self.kvDim = resolvedKVDim
+        self.qkvIn = qkvIn
+        self.kOut = kOut
+        self.qOut = qOut
+        self.vOut = vOut
+        self.projectionContextIn = projectionContextIn
+        self.projectionResidualIn = qkvIn
+        self.projectionOut = projectionOut
+        self.ffnIn = kernels.usesFusedPostAttention ? qkvIn : projectionOut
+        self.ffnOut = ffnOut
+        self.maxSeq = logicalMaxSeq ?? kernels.maxSeq
+        self.laneSpatial = kernels.laneSpatial
+
+        guard let kCacheFull = ane_interop_create_surface(resolvedKVDim * self.maxSeq * 2),
+              let vCacheFull = ane_interop_create_surface(resolvedKVDim * self.maxSeq * 2),
+              let zeroLane = ane_interop_create_surface(dim * kernels.laneSpatial * 2) else {
+            throw .surfaceAllocationFailed
+        }
+        self.kCacheFull = kCacheFull
+        self.vCacheFull = vCacheFull
+        self.zeroLane = zeroLane
+
+        let zeroLaneValues = Array(repeating: Float(0), count: dim * kernels.laneSpatial)
+        try mapSurfaceIOToANEError { try zeroLaneValues.withUnsafeBufferPointer { src in
+            try SurfaceIO.writeFP16(to: zeroLane, data: src, channels: dim, spatial: kernels.laneSpatial)
+        } }
+    }
+}
+
+/// Surfaces for one Phase-11 `max_N = 1` fused hybrid layer.
+///
+/// Inputs (alphabetical): kCache, mask, posMask, ropePack, vCache, x
+/// Outputs (alphabetical): kNew, vNew, xOut
+///
+/// Binding knowledge travels with the kernel set that defines the layout;
+/// shared mask/rope surfaces can be rebound by the caller without knowing
+/// positional indices.
+public struct FusedHybridDecodeSurfaceHandles {
+    public let kCache: IOSurfaceRef
+    public let mask: IOSurfaceRef
+    public let posMask: IOSurfaceRef
+    public let ropePack: IOSurfaceRef
+    public let vCache: IOSurfaceRef
+    public let xIn: IOSurfaceRef
+    public let kNew: IOSurfaceRef
+    public let vNew: IOSurfaceRef
+    public let xOut: IOSurfaceRef
+    public let maxSeq: Int
+    public let laneSpatial: Int
+    public let dim: Int
+    public let kvDim: Int
+
+    public init(
+        kernels: borrowing FusedHybridDecodeLayerKernelSet,
+        sharedMask: IOSurfaceRef? = nil,
+        sharedPosMask: IOSurfaceRef? = nil,
+        sharedRopePack: IOSurfaceRef? = nil
+    ) throws(ANEError) {
+        self.kCache = try kernels.fusedLayer.inputSurface(at: 0)
+        let ownedMask = try kernels.fusedLayer.inputSurface(at: 1)
+        let ownedPos = try kernels.fusedLayer.inputSurface(at: 2)
+        let ownedRope = try kernels.fusedLayer.inputSurface(at: 3)
+        self.vCache = try kernels.fusedLayer.inputSurface(at: 4)
+        self.xIn = try kernels.fusedLayer.inputSurface(at: 5)
+        self.kNew = try kernels.fusedLayer.outputSurface(at: 0)
+        self.vNew = try kernels.fusedLayer.outputSurface(at: 1)
+        self.xOut = try kernels.fusedLayer.outputSurface(at: 2)
+        self.maxSeq = kernels.maxSeq
+        self.laneSpatial = kernels.laneSpatial
+        self.dim = kernels.dim
+        self.kvDim = kernels.kvDim
+
+        if let sharedMask {
+            try kernels.fusedLayer.rebindInput(at: 1, to: sharedMask)
+            self.mask = sharedMask
+        } else {
+            self.mask = ownedMask
+        }
+        if let sharedPosMask {
+            try kernels.fusedLayer.rebindInput(at: 2, to: sharedPosMask)
+            self.posMask = sharedPosMask
+        } else {
+            self.posMask = ownedPos
+        }
+        if let sharedRopePack {
+            try kernels.fusedLayer.rebindInput(at: 3, to: sharedRopePack)
+            self.ropePack = sharedRopePack
+        } else {
+            self.ropePack = ownedRope
+        }
+    }
+}

--- a/Sources/Espresso/DecodeForwardPass.swift
+++ b/Sources/Espresso/DecodeForwardPass.swift
@@ -432,84 +432,6 @@ public struct HybridDecodeTokenProfile: Sendable {
     }
 }
 
-/// Decode surfaces for the split hybrid path:
-/// ANE QKV-only -> Metal attention/projection -> ANE FFN.
-///
-/// Supports GQA: K/V caches use `kvDim` (nKVHeads * headDim) which may differ from `dim`.
-public struct HybridDecodeSurfaceHandles {
-    public let qkvIn: IOSurfaceRef
-    public let qOut: IOSurfaceRef
-    public let kOut: IOSurfaceRef
-    public let vOut: IOSurfaceRef
-    public let projectionContextIn: IOSurfaceRef
-    public let projectionResidualIn: IOSurfaceRef
-    public let projectionOut: IOSurfaceRef
-    public let ffnIn: IOSurfaceRef
-    public let ffnOut: IOSurfaceRef
-    public let kCacheFull: IOSurfaceRef
-    public let vCacheFull: IOSurfaceRef
-    public let zeroLane: IOSurfaceRef
-    public let maxSeq: Int
-    public let laneSpatial: Int
-
-    public let dim: Int
-    public let qDim: Int
-    public let kvDim: Int
-
-    public init(
-        kernels: borrowing HybridDecodeKernelSet,
-        logicalMaxSeq: Int? = nil,
-        dim: Int = ModelConfig.dim,
-        qDim: Int? = nil,
-        kvDim: Int? = nil
-    ) throws(ANEError) {
-        let resolvedQDim = qDim ?? dim
-        let resolvedKVDim = kvDim ?? dim
-        let qkvIn = try kernels.decodeQKVOnly.inputSurface(at: 0)
-        let kOut = try kernels.decodeQKVOnly.outputSurface(at: 0)
-        let qOut = try kernels.decodeQKVOnly.outputSurface(at: 1)
-        let vOut = try kernels.decodeQKVOnly.outputSurface(at: 2)
-        let projectionContextIn = try kernels.decodeProjection.inputSurface(at: 0)
-        let projectionOut = try kernels.decodeProjection.outputSurface(at: 0)
-        let ffnOut = try (kernels.usesFusedPostAttention
-            ? kernels.decodeProjection.outputSurface(at: 0)
-            : kernels.decodeFFN.outputSurface(at: 0))
-        try kernels.decodeProjection.rebindInput(at: 1, to: qkvIn)
-        if !kernels.usesFusedPostAttention {
-            try kernels.decodeFFN.rebindInput(at: 0, to: projectionOut)
-        }
-
-        self.dim = dim
-        self.qDim = resolvedQDim
-        self.kvDim = resolvedKVDim
-        self.qkvIn = qkvIn
-        self.kOut = kOut
-        self.qOut = qOut
-        self.vOut = vOut
-        self.projectionContextIn = projectionContextIn
-        self.projectionResidualIn = qkvIn
-        self.projectionOut = projectionOut
-        self.ffnIn = kernels.usesFusedPostAttention ? qkvIn : projectionOut
-        self.ffnOut = ffnOut
-        self.maxSeq = logicalMaxSeq ?? kernels.maxSeq
-        self.laneSpatial = kernels.laneSpatial
-
-        guard let kCacheFull = ane_interop_create_surface(resolvedKVDim * self.maxSeq * 2),
-              let vCacheFull = ane_interop_create_surface(resolvedKVDim * self.maxSeq * 2),
-              let zeroLane = ane_interop_create_surface(dim * kernels.laneSpatial * 2) else {
-            throw .surfaceAllocationFailed
-        }
-        self.kCacheFull = kCacheFull
-        self.vCacheFull = vCacheFull
-        self.zeroLane = zeroLane
-
-        let zeroLaneValues = Array(repeating: Float(0), count: dim * kernels.laneSpatial)
-        try mapSurfaceIOToANEError { try zeroLaneValues.withUnsafeBufferPointer { src in
-            try SurfaceIO.writeFP16(to: zeroLane, data: src, channels: dim, spatial: kernels.laneSpatial)
-        } }
-    }
-}
-
 /// Decode surfaces for one layer using the fused (attn + FFN) kernel.
 ///
 /// The fused kernel has 4 inputs and 3 outputs:
@@ -1282,10 +1204,7 @@ public extension ForwardPass {
                     // Run previous layer's ANE ProjFFN (it reads the Metal context output)
                     t0 = RuntimeClock.now()
                     do {
-                        try kernels[layerIndex - 1].decodeProjection.eval()
-                        if !kernels[layerIndex - 1].usesFusedPostAttention {
-                            try kernels[layerIndex - 1].decodeFFN.eval()
-                        }
+                        try kernels[layerIndex - 1].evalPostAttention()
                     } catch {
                         throw .invalidArguments("hybrid ProjFFN pipelined failed at layer \(layerIndex - 1): \(error)")
                     }
@@ -1413,10 +1332,7 @@ public extension ForwardPass {
                 let lastLayer = kernels.count - 1
                 t0 = RuntimeClock.now()
                 do {
-                    try kernels[lastLayer].decodeProjection.eval()
-                    if !kernels[lastLayer].usesFusedPostAttention {
-                        try kernels[lastLayer].decodeFFN.eval()
-                    }
+                    try kernels[lastLayer].evalPostAttention()
                 } catch {
                     throw .invalidArguments("hybrid ProjFFN final failed: \(error)")
                 }
@@ -1478,15 +1394,9 @@ public extension ForwardPass {
                     timings.tMetal += RuntimeClock.ms(RuntimeClock.now() - t0)
 
                     t0 = RuntimeClock.now()
-                    try kernels[layerIndex].decodeProjection.eval()
-                    if !kernels[layerIndex].usesFusedPostAttention {
-                        try kernels[layerIndex].decodeFFN.eval()
-                    }
+                    try kernels[layerIndex].evalPostAttention()
                 } catch {
-                    let kernelName = kernels[layerIndex].usesFusedPostAttention
-                        ? "decodeProjectionFFN"
-                        : "decodeProjection+decodeFFN"
-                    throw .invalidArguments("hybrid \(kernelName) failed at layer \(layerIndex), token \(tokenIndex): \(error)")
+                    throw .invalidArguments("hybrid \(kernels[layerIndex].postAttentionStageName) failed at layer \(layerIndex), token \(tokenIndex): \(error)")
                 }
                 timings.tAneFFN += RuntimeClock.ms(RuntimeClock.now() - t0)
 
@@ -1587,15 +1497,9 @@ public extension ForwardPass {
                     timings.tMetal += RuntimeClock.ms(RuntimeClock.now() - t0)
 
                     t0 = RuntimeClock.now()
-                    try kernels[layerIndex].decodeProjection.eval()
-                    if !kernels[layerIndex].usesFusedPostAttention {
-                        try kernels[layerIndex].decodeFFN.eval()
-                    }
+                    try kernels[layerIndex].evalPostAttention()
                 } catch {
-                    let kernelName = kernels[layerIndex].usesFusedPostAttention
-                        ? "decodeProjectionFFN"
-                        : "decodeProjection+decodeFFN"
-                    throw .invalidArguments("hybrid \(kernelName) failed at layer \(layerIndex), token \(tokenIndex): \(error)")
+                    throw .invalidArguments("hybrid \(kernels[layerIndex].postAttentionStageName) failed at layer \(layerIndex), token \(tokenIndex): \(error)")
                 }
                 timings.tAneFFN += RuntimeClock.ms(RuntimeClock.now() - t0)
 

--- a/Sources/Espresso/FusedHybridDecodeForward.swift
+++ b/Sources/Espresso/FusedHybridDecodeForward.swift
@@ -5,66 +5,6 @@ import ANERuntime
 import ANETypes
 import CPUOps
 
-/// Surfaces for one Phase-11 `max_N = 1` fused layer.
-///
-/// Inputs (alphabetical): kCache, mask, posMask, ropePack, vCache, x
-/// Outputs (alphabetical): kNew, vNew, xOut
-public struct FusedHybridDecodeSurfaceHandles {
-    public let kCache: IOSurfaceRef
-    public let mask: IOSurfaceRef
-    public let posMask: IOSurfaceRef
-    public let ropePack: IOSurfaceRef
-    public let vCache: IOSurfaceRef
-    public let xIn: IOSurfaceRef
-    public let kNew: IOSurfaceRef
-    public let vNew: IOSurfaceRef
-    public let xOut: IOSurfaceRef
-    public let maxSeq: Int
-    public let laneSpatial: Int
-    public let dim: Int
-    public let kvDim: Int
-
-    public init(
-        kernels: borrowing FusedHybridDecodeLayerKernelSet,
-        sharedMask: IOSurfaceRef? = nil,
-        sharedPosMask: IOSurfaceRef? = nil,
-        sharedRopePack: IOSurfaceRef? = nil
-    ) throws(ANEError) {
-        self.kCache = try kernels.fusedLayer.inputSurface(at: 0)
-        let ownedMask = try kernels.fusedLayer.inputSurface(at: 1)
-        let ownedPos = try kernels.fusedLayer.inputSurface(at: 2)
-        let ownedRope = try kernels.fusedLayer.inputSurface(at: 3)
-        self.vCache = try kernels.fusedLayer.inputSurface(at: 4)
-        self.xIn = try kernels.fusedLayer.inputSurface(at: 5)
-        self.kNew = try kernels.fusedLayer.outputSurface(at: 0)
-        self.vNew = try kernels.fusedLayer.outputSurface(at: 1)
-        self.xOut = try kernels.fusedLayer.outputSurface(at: 2)
-        self.maxSeq = kernels.maxSeq
-        self.laneSpatial = kernels.laneSpatial
-        self.dim = kernels.dim
-        self.kvDim = kernels.kvDim
-
-        if let sharedMask {
-            try kernels.fusedLayer.rebindInput(at: 1, to: sharedMask)
-            self.mask = sharedMask
-        } else {
-            self.mask = ownedMask
-        }
-        if let sharedPosMask {
-            try kernels.fusedLayer.rebindInput(at: 2, to: sharedPosMask)
-            self.posMask = sharedPosMask
-        } else {
-            self.posMask = ownedPos
-        }
-        if let sharedRopePack {
-            try kernels.fusedLayer.rebindInput(at: 3, to: sharedRopePack)
-            self.ropePack = sharedRopePack
-        } else {
-            self.ropePack = ownedRope
-        }
-    }
-}
-
 extension ForwardPass {
     public static func initializeFusedHybridDecodeCaches(
         surfaceHandles: [FusedHybridDecodeSurfaceHandles]


### PR DESCRIPTION
## What

Deepens the kernel-set seam for both llama hybrid trunks:

1. **`HybridDecodeSurfaceHandles` and `FusedHybridDecodeSurfaceHandles` move from `Sources/Espresso` into ANERuntime** (`HybridDecodeSurfaceBindings.swift`), beside the kernel sets whose layouts they encode. These types carry the binding lore — positional surface indices, projection/FFN rebind choreography, fp16 KV-cache byte math, shared-mask rebinding — that previously lived inside a consumer module while describing another module's implementation detail. Public API is unchanged; every consumer (DecodeForwardPass, RealModelInferenceEngine, tests) compiles untouched.

2. **`HybridDecodeKernelSet` gains `evalPostAttention()` / `postAttentionStageName`.** The four eval sites in `DecodeForwardPass` no longer branch on `usesFusedPostAttention` or hand-roll the stage label in error strings; they call one method and let the kernel set decide fused vs split.

3. **`mapSurfaceIOToANEError` moves to ANERuntime** (public, next to `ANEError` which it produces). Espresso's private copy is deleted; its other two error bridges stay.

## Why

- **Seam direction fixed:** kernel sets now expose *bound stages*; consumers no longer reach past the interface to assemble steps from raw kernels + booleans.
- **Locality:** a MIL layout change (input/output ordering, cache sizing) now updates one module instead of also hunting consumer-side index tables.
- **Leverage:** two consumers (harness trunk loops + serving engine) share the same binding code; the engine's split-hybrid loops were a verbatim twin waiting to drift.
- Mid-layer decode wiring becomes testable without hardware once fakes exist at this seam — `ANEKernel` being `~Copyable` was blocking that from the wrong side.

## Verification

- `swift build` green
- `swift test`: 540 executed, 0 failures (169 hardware-gated skips), identical to baseline
- Hybrid/fused decode parity tests (`fusedDecodeLayerParity`, `rwkv*Parity`, generator parity suites) pass unchanged

Stacked on #31; merge order matters only for conflict-free review.
