### PR TITLE
T2: shared emission core across seven decode loops

### DIFF
--- a/Sources/RealModelInference/EmissionCore.swift
+++ b/Sources/RealModelInference/EmissionCore.swift
@@ -1,0 +1,183 @@
+import Foundation
+import ANETypes
+import ModelSupport
+
+/// Where the end-of-sequence token id comes from for one decode loop.
+///
+/// Injected per model family so no loop hardcodes an EOS source: GPT-2
+/// sessions pass the fixed tokenizer constant, llama sessions pass the
+/// artifact's optional `config.eosToken`.
+enum EOSPolicy: Sendable, Equatable {
+    /// One constant token id that always terminates decoding (GPT-2 family).
+    case fixed(Int)
+    /// The model config's optional `eosToken`; `nil` disables EOS termination.
+    case fromConfig(Int?)
+}
+
+/// Accumulator owning the four emission concerns shared by every decode loop:
+///
+/// 1. first-token latency capture,
+/// 2. tokens-per-second computation,
+/// 3. ``GenerationStep`` construction for `onStep` callbacks,
+/// 4. final ``GenerationResult`` assembly.
+///
+/// Loops keep their own KV-cache handling, speculative-draft logic, and
+/// early-return shapes; this type owns only how emitted tokens turn into
+/// telemetry and results. Per-token latencies measure emission-to-emission,
+/// starting from session start.
+struct EmissionCore {
+    /// Resolved end-of-sequence id under the injected policy, or `nil` when
+    /// this run never terminates early.
+    private(set) var eosTokenID: Int?
+
+    /// Session start clock used by every latency and rate computation.
+    private let startNanos: UInt64
+    /// Clock of the previous emission (initialized to session start).
+    private var lastEmissionNanos: UInt64
+    private var firstTokenLatencyMsValue = 0.0
+    private var firstTokenRecorded = false
+
+    /// Prompt plus every fully emitted token; the text carrier.
+    private(set) var allTokens: [TokenID]
+    /// Emitted output tokens; llama-family terminal tokens land here only.
+    private(set) var generatedTokens: [TokenID]
+    private(set) var tokenLatenciesMs: [Double]
+
+    private let promptTokens: [TokenID]
+    private let onStep: ((GenerationStep) -> Void)?
+    private let decodeText: ([Int]) -> String
+
+    init(
+        promptTokens: [TokenID],
+        capacity: Int,
+        eos: EOSPolicy,
+        onStep: ((GenerationStep) -> Void)?,
+        decodeText: @escaping ([Int]) -> String,
+        startNanos: UInt64 = DispatchTime.now().uptimeNanoseconds
+    ) {
+        self.eosTokenID = switch eos {
+        case .fixed(let tokenID): tokenID
+        case .fromConfig(let tokenID): tokenID
+        }
+        self.startNanos = startNanos
+        self.lastEmissionNanos = startNanos
+        self.allTokens = promptTokens
+        self.generatedTokens = []
+        self.generatedTokens.reserveCapacity(capacity)
+        self.tokenLatenciesMs = []
+        self.tokenLatenciesMs.reserveCapacity(capacity)
+        self.promptTokens = promptTokens
+        self.onStep = onStep
+        self.decodeText = decodeText
+    }
+
+    // MARK: Loop control inputs
+
+    /// Whether `token` ends decoding under the injected ``EOSPolicy``.
+    func terminatesDecoding(_ token: TokenID) -> Bool {
+        guard let eosTokenID else { return false }
+        return Int(token) == eosTokenID
+    }
+
+    /// Fully emitted tokens so far.
+    var generatedTokenCount: Int { generatedTokens.count }
+    /// Prompt plus fully emitted tokens so far.
+    var allTokensCount: Int { allTokens.count }
+    /// First-token latency captured so far (`0` before the first emission point).
+    var firstTokenLatencyMs: Double { firstTokenLatencyMsValue }
+
+    // MARK: The four concerns
+
+    /// Concern 1 — first-token latency capture.
+    ///
+    /// Idempotent: loops that must record before their EOS check call this
+    /// explicitly, and ``emit(_:at:)`` calls it again as a safety net for
+    /// closure-style loops whose only capture point is the emit itself.
+    mutating func recordFirstTokenIfFirst(at now: UInt64) {
+        guard !firstTokenRecorded else { return }
+        firstTokenLatencyMsValue = Self.milliseconds(from: now - startNanos)
+        firstTokenRecorded = true
+    }
+
+    /// Concerns 1–3 — record one fully emitted token.
+    ///
+    /// Appends to both token arrays, records the per-token latency against the
+    /// previous emission clock, updates the running rate, and fires `onStep`
+    /// with the constructed step.
+    mutating func emit(_ token: TokenID, at now: UInt64) {
+        generatedTokens.append(token)
+        allTokens.append(token)
+        let tokenLatencyMs = Self.milliseconds(from: now - lastEmissionNanos)
+        tokenLatenciesMs.append(tokenLatencyMs)
+        recordFirstTokenIfFirst(at: now)
+        let elapsedMs = Self.milliseconds(from: now - startNanos)
+        let tokensPerSecond = Self.tokensPerSecond(
+            count: generatedTokens.count,
+            elapsedMs: elapsedMs
+        )
+        onStep?(
+            GenerationStep(
+                token: token,
+                generatedTokens: generatedTokens,
+                text: decodeText(allTokens.map(Int.init)),
+                tokenLatencyMs: tokenLatencyMs,
+                elapsedMs: elapsedMs,
+                firstTokenLatencyMs: firstTokenLatencyMsValue,
+                tokensPerSecond: tokensPerSecond
+            )
+        )
+        lastEmissionNanos = now
+    }
+
+    /// Record a llama-family terminal token: it lands in the reported `tokens`
+    /// array but not in the decoded text, and fires no step callback.
+    mutating func recordTerminalToken(_ token: TokenID) {
+        generatedTokens.append(token)
+    }
+
+    /// Concern 4 — assemble the final result from accumulated state plus the
+    /// trunk-level fields only this loop knows.
+    func makeResult(
+        compileTimeMs: Double,
+        exactHeadBackend: String? = nil,
+        cachedBindingsEnabled: Bool = false,
+        committedExactTokensPerPass: Double? = nil,
+        acceptedFutureTokensPerPass: Double? = nil,
+        trunk: Trunk? = nil,
+        hopsPerToken: Int? = nil,
+        decodeProfileReport: String? = nil,
+        tokensPerSecondOverride: Double? = nil,
+        textOverride: String? = nil,
+        at now: UInt64 = DispatchTime.now().uptimeNanoseconds
+    ) -> GenerationResult {
+        GenerationResult(
+            text: textOverride ?? decodeText(allTokens.map(Int.init)),
+            tokens: generatedTokens,
+            promptTokens: promptTokens,
+            tokenLatenciesMs: tokenLatenciesMs,
+            tokensPerSecond: tokensPerSecondOverride ?? Self.tokensPerSecond(
+                count: generatedTokens.count,
+                elapsedMs: Self.milliseconds(from: now - startNanos)
+            ),
+            compileTimeMs: compileTimeMs,
+            firstTokenLatencyMs: firstTokenLatencyMsValue,
+            exactHeadBackend: exactHeadBackend ?? "unknown",
+            cachedBindingsEnabled: cachedBindingsEnabled,
+            committedExactTokensPerPass: committedExactTokensPerPass,
+            acceptedFutureTokensPerPass: acceptedFutureTokensPerPass,
+            trunk: trunk,
+            hopsPerToken: hopsPerToken,
+            decodeProfileReport: decodeProfileReport
+        )
+    }
+
+    /// Concern 2 — the one rate formula used in-loop and at result assembly.
+    static func tokensPerSecond(count: Int, elapsedMs: Double) -> Double {
+        guard count > 0 else { return 0 }
+        return Double(count) / max(elapsedMs / 1_000, 1e-9)
+    }
+
+    private static func milliseconds(from nanoseconds: UInt64) -> Double {
+        Double(nanoseconds) / 1_000_000
+    }
+}

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -1853,7 +1853,17 @@ public struct RealModelInferenceEngine: ~Copyable {
         let seam = Self.resolveDecodePlanSeam(config: config, options: decodeOptions, environment: environment)
         let plan = seam.plan
         if effectiveMaxTokens == 0 {
-            let text = tokenizer.decode(promptTokens.map(Int.init))
+            let tokenizer = self.tokenizer
+            let eosPolicy: EOSPolicy = config.architecture == .llama
+                ? .fromConfig(config.eosToken.map(Int.init))
+                : .fixed(Int(Self.gpt2EOSToken))
+            let emission = EmissionCore(
+                promptTokens: promptTokens,
+                capacity: 0,
+                eos: eosPolicy,
+                onStep: nil,
+                decodeText: { tokenizer.decode($0) }
+            )
             var trunk: Trunk?
             var hopsPerToken: Int?
             if config.architecture == .llama {
@@ -1862,16 +1872,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     ? Self.fusedHopsPerToken(nLayer: config.nLayer)
                     : nil
             }
-            return GenerationResult(
-                text: text,
-                tokens: [],
-                promptTokens: promptTokens,
-                tokensPerSecond: 0,
-                compileTimeMs: 0,
-                firstTokenLatencyMs: 0,
-                trunk: trunk,
-                hopsPerToken: hopsPerToken
-            )
+            return emission.makeResult(compileTimeMs: 0, trunk: trunk, hopsPerToken: hopsPerToken)
         }
 
         let targetTokenCount = min(config.maxSeq, promptTokens.count + effectiveMaxTokens)
@@ -2032,22 +2033,22 @@ public struct RealModelInferenceEngine: ~Copyable {
             throw RealModelInferenceError.runtimeFailure("Compiled ANE surfaces are unavailable")
         }
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
-
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fixed(Int(Self.gpt2EOSToken)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var rng = SystemRandomNumberGenerator()
         let activeBucket = compiledBucket
 
         for _ in 0..<effectiveMaxTokens {
-            let stepStart = DispatchTime.now().uptimeNanoseconds
-            let sequenceLength = allTokens.count
-            let activation = composeEmbeddingInput(tokens: allTokens, spatial: activeBucket)
+            let sequenceLength = emission.allTokensCount
+            let activation = composeEmbeddingInput(tokens: emission.allTokens, spatial: activeBucket)
             try activation.withUnsafeBufferPointer { buffer in
                 try Self.writeFP32(to: inputSurface, data: buffer)
             }
@@ -2085,51 +2086,21 @@ public struct RealModelInferenceEngine: ~Copyable {
                 using: &rng
             )
 
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: DispatchTime.now().uptimeNanoseconds - generationStart)
-                firstTokenRecorded = true
-            }
+            let emissionNow = DispatchTime.now().uptimeNanoseconds
+            emission.recordFirstTokenIfFirst(at: emissionNow)
 
-            if nextToken == Self.gpt2EOSToken {
+            if emission.terminatesDecoding(nextToken) {
                 break
             }
 
-            generatedTokens.append(nextToken)
-            allTokens.append(nextToken)
-            let elapsedMs = Self.milliseconds(from: DispatchTime.now().uptimeNanoseconds - generationStart)
-            let tokenLatencyMs = Self.milliseconds(from: DispatchTime.now().uptimeNanoseconds - stepStart)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            onStep?(
-                GenerationStep(
-                    token: nextToken,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
-            if allTokens.count >= config.maxSeq {
+            emission.emit(nextToken, at: emissionNow)
+            if emission.allTokensCount >= config.maxSeq {
                 break
             }
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
             cachedBindingsEnabled: false
         )
@@ -5335,21 +5306,21 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
-
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fixed(Int(Self.gpt2EOSToken)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var rng = SystemRandomNumberGenerator()
         var normalized = [Float](repeating: 0, count: config.dModel)
         let headSpatial = compiledHybridHeadSpatial
 
-        while generatedTokens.count < effectiveMaxTokens {
+        while emission.generatedTokenCount < effectiveMaxTokens {
             try Self.throwIfCancelled(isCancelled)
             let nextToken: TokenID
             if useANEGreedyHead {
@@ -5407,39 +5378,19 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             }
             let emissionNow = DispatchTime.now().uptimeNanoseconds
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
+            emission.recordFirstTokenIfFirst(at: emissionNow)
 
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
-
-            if nextToken == Self.gpt2EOSToken {
+            if emission.terminatesDecoding(nextToken) {
                 break
             }
 
-            generatedTokens.append(nextToken)
-            allTokens.append(nextToken)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            onStep?(
-                GenerationStep(
-                    token: nextToken,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
+            emission.emit(nextToken, at: emissionNow)
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
                 break
             }
 
-            try writeIncrementalEmbedding(token: nextToken, position: allTokens.count - 1, into: xCur)
+            try writeIncrementalEmbedding(token: nextToken, position: emission.allTokensCount - 1, into: xCur)
             do {
                 try ForwardPass.runHybridDecodeTimed(
                     xCur: xCur,
@@ -5458,26 +5409,13 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid decode failed at generated token \(generatedTokens.count - 1): \(error)"
+                    "Hybrid decode failed at generated token \(emission.generatedTokenCount - 1): \(error)"
                 )
             }
-            emissionStart = emissionNow
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
             cachedBindingsEnabled: false
         )
@@ -5514,47 +5452,23 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
-
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fixed(Int(Self.gpt2EOSToken)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
 
-        func emitToken(_ token: TokenID, at emissionNow: UInt64) {
-            generatedTokens.append(token)
-            allTokens.append(token)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            onStep?(
-                GenerationStep(
-                    token: token,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
-        }
-
-        while generatedTokens.count < effectiveMaxTokens {
+        while emission.generatedTokenCount < effectiveMaxTokens {
             let checkpoint = try cachedRuntimePair.draftRuntime.captureCheckpoint(dim: config.dModel)
             let proposedToken0: TokenID
             do {
                 proposedToken0 = try cachedRuntimePair.draftRuntime.selectGreedyToken(vocab: config.vocab)
-                try writeIncrementalEmbedding(token: proposedToken0, position: allTokens.count, into: xCur)
+                try writeIncrementalEmbedding(token: proposedToken0, position: emission.allTokensCount, into: xCur)
                 try cachedRuntimePair.draftRuntime.advanceFromBuffer(
                     xCur,
                     metalAttention: metalAttention,
@@ -5562,7 +5476,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative draft proposal-0 failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative draft proposal-0 failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
 
@@ -5571,7 +5485,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 proposedToken1 = try cachedRuntimePair.draftRuntime.selectGreedyToken(vocab: config.vocab)
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative draft proposal-1 failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative draft proposal-1 failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
 
@@ -5580,10 +5494,10 @@ public struct RealModelInferenceEngine: ~Copyable {
                 exactToken0 = try cachedRuntimePair.verifierRuntime.selectGreedyToken(vocab: config.vocab)
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative verifier token-0 failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative verifier token-0 failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
-            if exactToken0 == Self.gpt2EOSToken {
+            if emission.terminatesDecoding(exactToken0) {
                 break
             }
 
@@ -5594,7 +5508,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                         mutatedTokenCount: 1,
                         dim: config.dModel
                     )
-                    try writeIncrementalEmbedding(token: exactToken0, position: allTokens.count, into: xCur)
+                    try writeIncrementalEmbedding(token: exactToken0, position: emission.allTokensCount, into: xCur)
                     try cachedRuntimePair.draftRuntime.advanceFromBuffer(
                         xCur,
                         metalAttention: metalAttention,
@@ -5607,14 +5521,13 @@ public struct RealModelInferenceEngine: ~Copyable {
                     )
                 } catch {
                     throw RealModelInferenceError.runtimeFailure(
-                        "Hybrid speculative verifier rollback failed at generated token \(generatedTokens.count): \(error)"
+                        "Hybrid speculative verifier rollback failed at generated token \(emission.generatedTokenCount): \(error)"
                     )
                 }
 
                 let emissionNow = DispatchTime.now().uptimeNanoseconds
-                emitToken(exactToken0, at: emissionNow)
-                emissionStart = emissionNow
-                if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
+                emission.emit(exactToken0, at: emissionNow)
+                if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
                     break
                 }
                 continue
@@ -5628,15 +5541,14 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative verifier promotion failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative verifier promotion failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
 
             let emissionAfterFirst = DispatchTime.now().uptimeNanoseconds
-            emitToken(exactToken0, at: emissionAfterFirst)
-            emissionStart = emissionAfterFirst
+            emission.emit(exactToken0, at: emissionAfterFirst)
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
                 break
             }
 
@@ -5645,16 +5557,16 @@ public struct RealModelInferenceEngine: ~Copyable {
                 exactToken1 = try cachedRuntimePair.verifierRuntime.selectGreedyToken(vocab: config.vocab)
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative verifier token-1 failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative verifier token-1 failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
-            if exactToken1 == Self.gpt2EOSToken {
+            if emission.terminatesDecoding(exactToken1) {
                 break
             }
 
             do {
                 let committedSecondToken = exactToken1 == proposedToken1 ? proposedToken1 : exactToken1
-                try writeIncrementalEmbedding(token: committedSecondToken, position: allTokens.count, into: xCur)
+                try writeIncrementalEmbedding(token: committedSecondToken, position: emission.allTokensCount, into: xCur)
                 try cachedRuntimePair.draftRuntime.advanceFromBuffer(
                     xCur,
                     metalAttention: metalAttention,
@@ -5667,34 +5579,19 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative commit failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative commit failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
 
             let emissionAfterSecond = DispatchTime.now().uptimeNanoseconds
-            emitToken(exactToken1, at: emissionAfterSecond)
-            emissionStart = emissionAfterSecond
+            emission.emit(exactToken1, at: emissionAfterSecond)
 
-            if allTokens.count >= config.maxSeq {
+            if emission.allTokensCount >= config.maxSeq {
                 break
             }
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
-            compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs
-        )
+        return emission.makeResult(compileTimeMs: compileTimeMs)
     }
 
     private mutating func cachedSpeculativeRuntimePair(
@@ -6131,23 +6028,24 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
         var decodeProfileTokens: [HybridDecodeTimingBreakdown] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
         decodeProfileTokens.reserveCapacity(effectiveMaxTokens)
         var pendingDecode = HybridDecodeTimingBreakdown()
 
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fromConfig(config.eosToken.map(Int.init)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var rng = SystemRandomNumberGenerator()
         var normalized = [Float](repeating: 0, count: config.dModel)
 
-        while generatedTokens.count < effectiveMaxTokens {
+        while emission.generatedTokenCount < effectiveMaxTokens {
             try Self.throwIfCancelled(isCancelled)
             let headStart = DispatchTime.now().uptimeNanoseconds
             normalized = xCur.withUnsafeBufferPointer {
@@ -6165,35 +6063,15 @@ public struct RealModelInferenceEngine: ~Copyable {
             )
             decodeProfileTokens.append(tokenProfile)
             let emissionNow = DispatchTime.now().uptimeNanoseconds
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
+            emission.recordFirstTokenIfFirst(at: emissionNow)
 
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
-
-            if let eosToken = config.eosToken, nextToken == eosToken {
-                generatedTokens.append(nextToken)
+            if emission.terminatesDecoding(nextToken) {
+                emission.recordTerminalToken(nextToken)
                 break
             }
-            generatedTokens.append(nextToken)
-            allTokens.append(nextToken)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            onStep?(
-                GenerationStep(
-                    token: nextToken,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
+            emission.emit(nextToken, at: emissionNow)
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
                 break
             }
 
@@ -6211,11 +6089,10 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw Self.fusedHybridFallbackError(
-                    reason: "fused N=1 decode failed at generated token \(generatedTokens.count - 1): \(error)"
+                    reason: "fused N=1 decode failed at generated token \(emission.generatedTokenCount - 1): \(error)"
                 )
             }
             pendingDecode = timings
-            emissionStart = emissionNow
         }
 
         let decodeProfileReport = decodeProfileTokens.isEmpty
@@ -6225,22 +6102,9 @@ public struct RealModelInferenceEngine: ~Copyable {
             fputs(decodeProfileReport + "\n", stderr)
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
-            cachedBindingsEnabled: false,
             trunk: .fusedHybrid,
             hopsPerToken: hopsPerToken,
             decodeProfileReport: decodeProfileReport
@@ -6571,24 +6435,25 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
         var decodeProfileTokens: [HybridDecodeTimingBreakdown] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
         decodeProfileTokens.reserveCapacity(effectiveMaxTokens)
         var pendingDecode = HybridDecodeTimingBreakdown()
 
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fromConfig(config.eosToken.map(Int.init)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var rng = SystemRandomNumberGenerator()
         var normalized = [Float](repeating: 0, count: config.dModel)
         let headSpatial = compiledHybridHeadSpatial
 
-        while generatedTokens.count < effectiveMaxTokens {
+        while emission.generatedTokenCount < effectiveMaxTokens {
             try Self.throwIfCancelled(isCancelled)
             let headStart = DispatchTime.now().uptimeNanoseconds
             let nextToken: TokenID
@@ -6657,35 +6522,15 @@ public struct RealModelInferenceEngine: ~Copyable {
             )
             decodeProfileTokens.append(tokenProfile)
             let emissionNow = DispatchTime.now().uptimeNanoseconds
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
+            emission.recordFirstTokenIfFirst(at: emissionNow)
 
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
-
-            if let eosToken = config.eosToken, nextToken == eosToken {
-                generatedTokens.append(nextToken)
+            if emission.terminatesDecoding(nextToken) {
+                emission.recordTerminalToken(nextToken)
                 break
             }
-            generatedTokens.append(nextToken)
-            allTokens.append(nextToken)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            onStep?(
-                GenerationStep(
-                    token: nextToken,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
+            emission.emit(nextToken, at: emissionNow)
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
                 break
             }
 
@@ -6715,11 +6560,10 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Llama hybrid decode failed at generated token \(generatedTokens.count - 1): \(error)"
+                    "Llama hybrid decode failed at generated token \(emission.generatedTokenCount - 1): \(error)"
                 )
             }
             pendingDecode = timings
-            emissionStart = emissionNow
         }
 
         let decodeProfileReport = decodeProfileTokens.isEmpty
@@ -6729,20 +6573,8 @@ public struct RealModelInferenceEngine: ~Copyable {
             fputs(decodeProfileReport + "\n", stderr)
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: greedyHeadMode == .classifierOnlyFactored && useANEGreedyHead
                 ? "ane_factored_classifier"
                 : classifierStrategy.exactHeadBackendLabel,
@@ -6812,80 +6644,36 @@ public struct RealModelInferenceEngine: ~Copyable {
         try fullRuntime.prefill(promptTokens: promptTokens)
         try draftRuntime.prefill(promptTokens: promptTokens)
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
-
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fromConfig(config.eosToken.map(Int.init)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var committedExactTokensTotal = 0
         var acceptedFutureTokensTotal = 0
         var speculativePassCount = 0
 
-        func emit(_ token: TokenID, at emissionNow: UInt64) {
-            generatedTokens.append(token)
-            allTokens.append(token)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            onStep?(
-                GenerationStep(
-                    token: token,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
-            emissionStart = emissionNow
-        }
-
         let firstToken = fullRuntime.selectGreedyToken()
-        if let eosToken = config.eosToken, firstToken == eosToken {
-            generatedTokens.append(firstToken)
-            return GenerationResult(
-                text: tokenizer.decode((promptTokens + generatedTokens).map(Int.init)),
-                tokens: generatedTokens,
-                promptTokens: promptTokens,
-                tokenLatenciesMs: tokenLatenciesMs,
-                tokensPerSecond: 0,
+        if emission.terminatesDecoding(firstToken) {
+            emission.recordTerminalToken(firstToken)
+            return emission.makeResult(
                 compileTimeMs: compileTimeMs,
-                firstTokenLatencyMs: 0,
                 exactHeadBackend: "cpu_exact_two_token_draft",
-                cachedBindingsEnabled: false,
-                committedExactTokensPerPass: nil,
-                acceptedFutureTokensPerPass: nil,
-                trunk: .exactCPU
+                trunk: .exactCPU,
+                textOverride: tokenizer.decode((promptTokens + [firstToken]).map(Int.init))
             )
         }
         let firstEmission = DispatchTime.now().uptimeNanoseconds
-        emit(firstToken, at: firstEmission)
-        if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
-            let totalMs = Self.milliseconds(from: DispatchTime.now().uptimeNanoseconds - generationStart)
-            let tps = generatedTokens.isEmpty ? 0 : Double(generatedTokens.count) / max(totalMs / 1_000, 1e-9)
-            return GenerationResult(
-                text: tokenizer.decode(allTokens.map(Int.init)),
-                tokens: generatedTokens,
-                promptTokens: promptTokens,
-                tokenLatenciesMs: tokenLatenciesMs,
-                tokensPerSecond: tps,
+        emission.emit(firstToken, at: firstEmission)
+        if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
+            return emission.makeResult(
                 compileTimeMs: compileTimeMs,
-                firstTokenLatencyMs: firstTokenLatencyMs,
                 exactHeadBackend: "cpu_exact_two_token_draft",
-                cachedBindingsEnabled: false,
-                committedExactTokensPerPass: nil,
-                acceptedFutureTokensPerPass: nil,
                 trunk: .exactCPU
             )
         }
@@ -6893,9 +6681,12 @@ public struct RealModelInferenceEngine: ~Copyable {
         try fullRuntime.advance(token: firstToken)
         try draftRuntime.advance(token: firstToken)
 
-        while generatedTokens.count < effectiveMaxTokens, allTokens.count < config.maxSeq {
+        while emission.generatedTokenCount < effectiveMaxTokens, emission.allTokensCount < config.maxSeq {
             speculativePassCount += 1
-            let remainingTokenBudget = min(effectiveMaxTokens - generatedTokens.count, config.maxSeq - allTokens.count)
+            let remainingTokenBudget = min(
+                effectiveMaxTokens - emission.generatedTokenCount,
+                config.maxSeq - emission.allTokensCount
+            )
             let draftCheckpoint = draftRuntime.captureCheckpoint()
             let proposedToken0 = draftRuntime.selectGreedyToken()
             try draftRuntime.advance(token: proposedToken0)
@@ -6911,9 +6702,9 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
 
             let firstRoundEmission = DispatchTime.now().uptimeNanoseconds
-            emit(exactToken0, at: firstRoundEmission)
+            emission.emit(exactToken0, at: firstRoundEmission)
             committedInPass += 1
-            if let eosToken = config.eosToken, exactToken0 == eosToken {
+            if emission.terminatesDecoding(exactToken0) {
                 committedExactTokensTotal += committedInPass
                 acceptedFutureTokensTotal += acceptedInPass
                 break
@@ -6923,7 +6714,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 try draftRuntime.advance(token: exactToken0)
             }
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq || remainingTokenBudget <= 1 {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq || remainingTokenBudget <= 1 {
                 committedExactTokensTotal += committedInPass
                 acceptedFutureTokensTotal += acceptedInPass
                 continue
@@ -6935,9 +6726,9 @@ public struct RealModelInferenceEngine: ~Copyable {
                 acceptedInPass += 1
             }
             let secondRoundEmission = DispatchTime.now().uptimeNanoseconds
-            emit(exactToken1, at: secondRoundEmission)
+            emission.emit(exactToken1, at: secondRoundEmission)
             committedInPass += 1
-            if let eosToken = config.eosToken, exactToken1 == eosToken {
+            if emission.terminatesDecoding(exactToken1) {
                 committedExactTokensTotal += committedInPass
                 acceptedFutureTokensTotal += acceptedInPass
                 break
@@ -6949,11 +6740,6 @@ public struct RealModelInferenceEngine: ~Copyable {
             acceptedFutureTokensTotal += acceptedInPass
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
         let committedExactTokensPerPass = speculativePassCount == 0
             ? nil
             : Double(committedExactTokensTotal) / Double(speculativePassCount)
@@ -6961,16 +6747,9 @@ public struct RealModelInferenceEngine: ~Copyable {
             ? nil
             : Double(acceptedFutureTokensTotal) / Double(speculativePassCount)
 
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: "cpu_exact_two_token_draft",
-            cachedBindingsEnabled: false,
             committedExactTokensPerPass: committedExactTokensPerPass,
             acceptedFutureTokensPerPass: acceptedFutureTokensPerPass,
             trunk: .exactCPU
@@ -7029,23 +6808,24 @@ public struct RealModelInferenceEngine: ~Copyable {
             return hidden
         }
 
-        var allTokens = promptTokens
         var lastHidden = [Float](repeating: 0, count: config.dModel)
         for (position, token) in promptTokens.enumerated() {
             lastHidden = try forwardToken(token, position: position)
         }
 
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fromConfig(config.eosToken.map(Int.init)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var rng = SystemRandomNumberGenerator()
 
-        while generatedTokens.count < effectiveMaxTokens {
+        while emission.generatedTokenCount < effectiveMaxTokens {
             try Self.throwIfCancelled(isCancelled)
             let normalized = Self.rmsNorm(lastHidden, weight: finalNormGamma, eps: Float(config.normEps))
             let nextToken: TokenID
@@ -7061,56 +6841,24 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
 
             let emissionNow = DispatchTime.now().uptimeNanoseconds
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
+            emission.recordFirstTokenIfFirst(at: emissionNow)
 
-            if let eosToken = config.eosToken, nextToken == eosToken {
-                generatedTokens.append(nextToken)
+            if emission.terminatesDecoding(nextToken) {
+                emission.recordTerminalToken(nextToken)
                 break
             }
 
-            generatedTokens.append(nextToken)
-            allTokens.append(nextToken)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            onStep?(
-                GenerationStep(
-                    token: nextToken,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
+            emission.emit(nextToken, at: emissionNow)
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= maxSeq {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= maxSeq {
                 break
             }
 
-            lastHidden = try forwardToken(nextToken, position: allTokens.count - 1)
-            emissionStart = emissionNow
+            lastHidden = try forwardToken(nextToken, position: emission.allTokensCount - 1)
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
             trunk: .exactCPU
         )

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -6665,6 +6665,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 compileTimeMs: compileTimeMs,
                 exactHeadBackend: "cpu_exact_two_token_draft",
                 trunk: .exactCPU,
+                tokensPerSecondOverride: 0,
                 textOverride: tokenizer.decode((promptTokens + [firstToken]).map(Int.init))
             )
         }

--- a/Tests/RealModelInferenceTests/EmissionCoreTests.swift
+++ b/Tests/RealModelInferenceTests/EmissionCoreTests.swift
@@ -1,0 +1,208 @@
+import Testing
+import ANETypes
+@testable import RealModelInference
+
+private func makeEmission(
+    promptTokens: [TokenID] = [10, 11],
+    capacity: Int = 8,
+    eos: EOSPolicy,
+    onStep: ((GenerationStep) -> Void)? = nil,
+    startNanos: UInt64 = 1_000_000_000
+) -> EmissionCore {
+    EmissionCore(
+        promptTokens: promptTokens,
+        capacity: capacity,
+        eos: eos,
+        onStep: onStep,
+        decodeText: { $0.map(String.init).joined(separator: ",") },
+        startNanos: startNanos
+    )
+}
+
+@Suite struct EmissionCoreTests {
+    // MARK: EOSPolicy injection
+
+    @Test func fixedPolicyTerminatesOnTheInjectedConstantOnly() {
+        let emission = makeEmission(eos: .fixed(50_256))
+        #expect(emission.eosTokenID == 50_256)
+        #expect(emission.terminatesDecoding(50_256))
+        #expect(!emission.terminatesDecoding(50_255))
+        #expect(!emission.terminatesDecoding(0))
+    }
+
+    @Test func fromConfigPolicyUsesTheArtifactValueAndNilDisablesEOS() {
+        let qwenLike = makeEmission(eos: .fromConfig(151_643))
+        #expect(qwenLike.terminatesDecoding(151_643))
+        #expect(!qwenLike.terminatesDecoding(151_644))
+
+        let noEOS = makeEmission(eos: .fromConfig(nil))
+        #expect(noEOS.eosTokenID == nil)
+        #expect(!noEOS.terminatesDecoding(0))
+    }
+
+    // MARK: Concern 1 — first-token latency capture
+
+    @Test func firstTokenLatencyIsZeroUntilCapturedThenIdempotent() {
+        var emission = makeEmission(eos: .fixed(50_256))
+        #expect(emission.firstTokenLatencyMs == 0)
+
+        emission.recordFirstTokenIfFirst(at: 1_002_500_000)
+        #expect(emission.firstTokenLatencyMs == 2.5)
+
+        emission.recordFirstTokenIfFirst(at: 1_900_000_000)
+        #expect(emission.firstTokenLatencyMs == 2.5)
+    }
+
+    @Test func emitCapturesFirstTokenLatencyWithoutExplicitRecord() {
+        var emission = makeEmission(eos: .fixed(50_256))
+        emission.emit(7, at: 1_004_000_000)
+        #expect(emission.firstTokenLatencyMs == 4)
+    }
+
+    // MARK: Concerns 1–3 — emit bookkeeping and step construction
+
+    @Test func emitAppendsTokensRecordsLatenciesAndFiresSteps() throws {
+        var steps: [GenerationStep] = []
+        var emission = makeEmission(eos: .fixed(50_256)) { steps.append($0) }
+
+        emission.emit(7, at: 1_001_000_000)
+        emission.emit(9, at: 1_003_500_000)
+
+        #expect(emission.generatedTokens == [7, 9])
+        #expect(emission.generatedTokenCount == 2)
+        #expect(emission.allTokens == [10, 11, 7, 9])
+        #expect(emission.allTokensCount == 4)
+        #expect(emission.tokenLatenciesMs.count == 2)
+
+        #expect(steps.count == 2)
+        let first = try #require(steps.first)
+        #expect(first.token == 7)
+        #expect(first.generatedTokens == [7])
+        #expect(first.text == "10,11,7")
+        #expect(first.tokenLatencyMs == 1)
+        #expect(first.elapsedMs == 1)
+        #expect(first.firstTokenLatencyMs == 1)
+
+        let second = try #require(steps.last)
+        #expect(second.token == 9)
+        #expect(second.generatedTokens == [7, 9])
+        #expect(second.text == "10,11,7,9")
+        #expect(second.tokenLatencyMs == 2.5)
+        #expect(second.elapsedMs == 3.5)
+        #expect(second.firstTokenLatencyMs == 1)
+        let secondTPS = EmissionCore.tokensPerSecond(count: 2, elapsedMs: 3.5)
+        #expect(abs(second.tokensPerSecond - secondTPS) < 1e-9)
+    }
+
+    @Test func terminalTokenLandsInTokensButNotTextAndFiresNoStep() {
+        var steps: [GenerationStep] = []
+        var emission = makeEmission(promptTokens: [10], eos: .fromConfig(99)) { steps.append($0) }
+
+        emission.recordTerminalToken(99)
+
+        #expect(emission.generatedTokens == [99])
+        #expect(emission.allTokens == [10])
+        #expect(steps.isEmpty)
+
+        let result = emission.makeResult(
+            compileTimeMs: 0,
+            trunk: .exactCPU,
+            at: 1_010_000_000
+        )
+        #expect(result.tokens == [99])
+        #expect(result.text == "10")
+        #expect(result.tokensPerSecond == 100)
+    }
+
+    // MARK: Concern 2 — one rate formula
+
+    @Test func tokensPerSecondFormulaIsSharedByLoopAndAssemblyPaths() {
+        #expect(EmissionCore.tokensPerSecond(count: 0, elapsedMs: 12.5) == 0)
+        let rate = EmissionCore.tokensPerSecond(count: 25, elapsedMs: 1_250)
+        #expect(abs(rate - 20) < 1e-9)
+
+        var emission = makeEmission(eos: .fixed(50_256))
+        emission.emit(1, at: 1_001_250_000)
+        let result = emission.makeResult(compileTimeMs: 0, at: 1_001_250_000)
+        #expect(abs(result.tokensPerSecond - EmissionCore.tokensPerSecond(count: 1, elapsedMs: 1.25)) < 1e-9)
+    }
+
+    // MARK: Concern 4 — result assembly
+
+    @Test func makeResultDefaultsRepresentTypeLevelAbsence() {
+        let emission = makeEmission(eos: .fixed(50_256))
+        let result = emission.makeResult(
+            compileTimeMs: 3.25,
+            at: 1_000_500_000
+        )
+        #expect(result.text == "10,11")
+        #expect(result.tokens.isEmpty)
+        #expect(result.promptTokens == [10, 11])
+        #expect(result.tokensPerSecond == 0)
+        #expect(result.compileTimeMs == 3.25)
+        #expect(result.firstTokenLatencyMs == 0)
+        #expect(result.trunk == nil)
+        #expect(result.decodePath == "unknown")
+        #expect(result.exactHeadBackend == "unknown")
+        #expect(!result.cachedBindingsEnabled)
+        #expect(result.hopsPerToken == nil)
+        #expect(result.decodeProfileReport == nil)
+    }
+
+    @Test func makeResultPopulatesTrunkFieldsWhenTheLoopSuppliesThem() {
+        var emission = makeEmission(eos: .fromConfig(nil))
+        emission.emit(5, at: 1_001_000_000)
+
+        let fused = emission.makeResult(
+            compileTimeMs: 0,
+            trunk: .fusedHybrid,
+            hopsPerToken: 6
+        )
+        #expect(fused.trunk == .fusedHybrid)
+        #expect(fused.hopsPerToken == 6)
+        #expect(fused.tokens == [5])
+
+        let split = emission.makeResult(compileTimeMs: 0, trunk: .splitHybrid)
+        #expect(split.trunk == .splitHybrid)
+        #expect(split.exactHeadBackend == "unknown")
+    }
+
+    @Test func makeResultOverridesServeDistinctEarlyReturnShapes() {
+        var emission = makeEmission(promptTokens: [10], eos: .fromConfig(99))
+        emission.recordTerminalToken(99)
+
+        let earlyReturn = emission.makeResult(
+            compileTimeMs: 1,
+            exactHeadBackend: "cpu_exact_two_token_draft",
+            trunk: .exactCPU,
+            tokensPerSecondOverride: 0,
+            textOverride: "10,99"
+        )
+        #expect(earlyReturn.tokens == [99])
+        #expect(earlyReturn.tokensPerSecond == 0)
+        #expect(earlyReturn.firstTokenLatencyMs == 0)
+        #expect(earlyReturn.text == "10,99")
+        #expect(earlyReturn.trunk == .exactCPU)
+
+        var running = makeEmission(eos: .fromConfig(nil))
+        running.emit(5, at: 1_002_000_000)
+        let budgetExhausted = running.makeResult(
+            compileTimeMs: 1,
+            exactHeadBackend: "cpu_exact_two_token_draft",
+            trunk: .exactCPU
+        )
+        #expect(budgetExhausted.committedExactTokensPerPass == nil)
+        #expect(budgetExhausted.acceptedFutureTokensPerPass == nil)
+        #expect(budgetExhausted.tokens == [5])
+
+        let finalPass = running.makeResult(
+            compileTimeMs: 1,
+            exactHeadBackend: "cpu_exact_two_token_draft",
+            committedExactTokensPerPass: 1.75,
+            acceptedFutureTokensPerPass: 0.5,
+            trunk: .exactCPU
+        )
+        #expect(finalPass.committedExactTokensPerPass == 1.75)
+        #expect(finalPass.acceptedFutureTokensPerPass == 0.5)
+    }
+}


### PR DESCRIPTION
## Ticket T2 — Shared emission core across seven decode loops

Stacked on **#30** (T1) · part of spec **`spec/spec-architecture-decode-serving-core.md`** (ticket DAG T1 → T2 → T3).

### What changed
- New internal `Sources/RealModelInference/EmissionCore.swift`: one implementation each of first-token latency capture, tokens-per-second computation, `GenerationStep`/`onStep` construction, and final `GenerationResult` assembly — previously duplicated ×7/×8 across the engine's seven decode loops (~400 deleted lines of copy-paste; net −69 lines).
- All seven loops (`generate` baseline, `Hybrid`, `HybridSpeculative`, `FusedHybridLlama`, `HybridLlama`, `ExactTwoTokenDraftLlama`, `ExactCPULlama`) now consume the emitter.
- EOS policy injected as an enum per model family (`.fixed(gpt2EOSToken)` / `.fromConfig(config.eosToken)`); trunk populated on every llama-path result via T1's plan; GPT-2 results keep type-level absence (no new string sentinels).
- New `EmissionCoreTests.swift` (10 tests) pinning latency semantics, EOS policies, partial-result assembly incl. zero-division guards.
- Parity suites (`QwenParityExactMatchTests`, `HybridLlamaDecodeStepTests`) pass **unmodified** — 0-diff files, token outputs byte-for-byte.

### Deliberate, reviewed deviation
Loop 1's per-token latency anchor unified onto the emission-to-emission chain already used by loops 2–7 (telemetry consistency only; token streams bit-identical). Accepted by adversarial review with base-line evidence.

### Review evidence
- Fresh-context review pass 1: `swift-adversarial-pr-review` — CLEAN after fixing a P1 regression (ExactTwoTokenDraft EOS-first early return had lost its zero-tps state).
- Fresh-context final pass: `swift-adversarial-pr-review` — CLEAN, no new findings, all dismissals upheld against base semantics re-derived from `git show`.

### Validation
- `swift build` ✓ · `EmissionCoreTests|QwenParity|HybridDecodeStep` 36 ✓ · full `RealModelInferenceTests` 142 ✓ (hardware-gated self-skips honored)
