### PR TITLE
Resolve engine environment once at build

### DIFF
--- a/Sources/ESPRuntime/ESPBundledRuntime.swift
+++ b/Sources/ESPRuntime/ESPBundledRuntime.swift
@@ -57,25 +57,31 @@ public enum ESPRuntimeRunner {
             maxTokens: maxTokens
         )
         let selection = try resolve(bundle: bundle, requestedContextTokens: requestedContextTokens)
-        return try withTemporaryEnvironment(environmentOverrides(for: selection)) {
-            switch selection.backend {
-            case .anePrivate:
-                var engine = try RealModelInferenceEngine.build(
-                    config: bundle.config,
-                    weightDir: bundle.archive.weightsURL.path,
-                    tokenizerDir: bundle.archive.tokenizerURL.path
-                )
-                return try engine.generate(prompt: prompt, maxTokens: maxTokens, temperature: temperature)
-            case .cpuSafe:
-                return try withTemporaryEnvironment(["ESPRESSO_USE_CPU_EXACT_DECODE": "1"]) {
-                    var engine = try RealModelInferenceEngine.build(
-                        config: bundle.config,
-                        weightDir: bundle.archive.weightsURL.path,
-                        tokenizerDir: bundle.archive.tokenizerURL.path
-                    )
-                    return try engine.generate(prompt: prompt, maxTokens: maxTokens, temperature: temperature)
-                }
-            }
+        // Manifest metadata crosses into the engine as parameters, not as
+        // process-global mutation: merge overrides into one dictionary and
+        // hand it to build(), which resolves everything once.
+        var environment = ProcessInfo.processInfo.environment
+        for (key, value) in environmentOverrides(for: selection) {
+            environment[key] = value
+        }
+        switch selection.backend {
+        case .anePrivate:
+            var engine = try RealModelInferenceEngine.build(
+                config: bundle.config,
+                weightDir: bundle.archive.weightsURL.path,
+                tokenizerDir: bundle.archive.tokenizerURL.path,
+                environment: environment
+            )
+            return try engine.generate(prompt: prompt, maxTokens: maxTokens, temperature: temperature)
+        case .cpuSafe:
+            environment["ESPRESSO_USE_CPU_EXACT_DECODE"] = "1"
+            var engine = try RealModelInferenceEngine.build(
+                config: bundle.config,
+                weightDir: bundle.archive.weightsURL.path,
+                tokenizerDir: bundle.archive.tokenizerURL.path,
+                environment: environment
+            )
+            return try engine.generate(prompt: prompt, maxTokens: maxTokens, temperature: temperature)
         }
     }
 
@@ -179,32 +185,3 @@ public enum ESPRuntimeRunner {
     }
 }
 
-private func withTemporaryEnvironment<T>(
-    _ overrides: [String: String],
-    operation: () throws -> T
-) throws -> T {
-    var original: [String: String?] = [:]
-    for key in overrides.keys {
-        if let pointer = getenv(key) {
-            original[key] = String(cString: pointer)
-        } else {
-            original[key] = nil
-        }
-    }
-
-    for (key, value) in overrides {
-        setenv(key, value, 1)
-    }
-
-    defer {
-        for (key, originalValue) in original {
-            if let originalValue {
-                setenv(key, originalValue, 1)
-            } else {
-                unsetenv(key)
-            }
-        }
-    }
-
-    return try operation()
-}

--- a/Sources/RealModelInference/EnginePolicies.swift
+++ b/Sources/RealModelInference/EnginePolicies.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Everything the process environment steers in this engine, resolved once
+/// when an engine is built.
+///
+/// The interface used to be "three build parameters plus ~78 undeclared
+/// environment variables read lazily mid-flight": callers had to `setenv`
+/// before calling, hot decode loops consulted `ProcessInfo` per token, and
+/// tests could only steer behavior by mutating process-global state. Now one
+/// dictionary crosses the seam at build time and nothing inside reads live
+/// process state while serving.
+///
+/// Typed fields exist for knobs consulted on hot or failure paths; every
+/// other knob flows through the frozen snapshot into the pure
+/// `(config:environment:)` policy functions, which stay injectable for tests.
+struct EnginePolicies: Sendable {
+    /// Frozen snapshot. Policy statics (`selectTrunk`, `resolvedTrunk`,
+    /// `prefersCPUDecodeAttention`, ...) receive this instead of live
+    /// `ProcessInfo`.
+    let environment: [String: String]
+
+    /// `ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK=1`: hybrid fast-path
+    /// failures become hard errors instead of silent fallbacks.
+    let disableHybridFallback: Bool
+
+    /// `ESPRESSO_REALMODEL_DEBUG_HYBRID_CACHE=1`: print hybrid surface geometry.
+    let debugHybridCacheDumps: Bool
+
+    /// `ESPRESSO_DUMP_LM_HEAD_HIDDEN=<path>`: stream hidden states to disk.
+    let lmHeadHiddenDumpPath: String?
+
+    init(environment: [String: String]) {
+        self.environment = environment
+        self.disableHybridFallback = environment["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK"] == "1"
+        self.debugHybridCacheDumps = environment["ESPRESSO_REALMODEL_DEBUG_HYBRID_CACHE"] == "1"
+        self.lmHeadHiddenDumpPath = environment["ESPRESSO_DUMP_LM_HEAD_HIDDEN"]
+    }
+
+    static func resolve(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> EnginePolicies {
+        EnginePolicies(environment: environment)
+    }
+}

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -1515,6 +1515,7 @@ public struct RealModelInferenceEngine: ~Copyable {
     private let classifierBlockMaxNorms: [Float]
     private var classifierLogitsScratch: [Float]
     private let classifierStrategy: ClassifierStrategy
+    private let policies: EnginePolicies
     private var cachedExactCPULlamaWeights: CachedExactCPULlamaWeights?
 
     private init(
@@ -1522,7 +1523,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         weightDirURL: URL,
         tokenizer: LoadedTokenizer,
         assets: TopLevelAssets,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        policies: EnginePolicies = .resolve()
     ) {
         let lmHead: [Float]
         let hasExactFloat32LMHead: Bool
@@ -1573,15 +1574,21 @@ public struct RealModelInferenceEngine: ~Copyable {
         self.classifierStrategy = Self.resolveClassifierStrategy(
             config: config,
             hasExactFloat32LMHead: hasExactFloat32LMHead,
-            environment: environment
+            environment: policies.environment
         )
+        self.policies = policies
         self.cachedExactCPULlamaWeights = nil
     }
 
+    /// Builds an engine. `environment` is the single configuration seam:
+    /// everything the process environment would have steered is resolved from
+    /// this dictionary once, here. Callers embedding Espresso pass values;
+    /// only the default reads the live process environment.
     public static func build(
         config: MultiModelConfig,
         weightDir: String,
-        tokenizerDir: String
+        tokenizerDir: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> RealModelInferenceEngine {
         try validateConfig(config)
 
@@ -1592,17 +1599,20 @@ public struct RealModelInferenceEngine: ~Copyable {
         try validateMetadataIfPresent(config: config, weightDirURL: weightDirURL)
 
         let tokenizer = try loadTokenizer(config: config, tokenizerDirURL: tokenizerDirURL)
+        let policies = EnginePolicies(environment: environment)
 
         let topLevelAssets = try TopLevelAssetLoader.load(
             config: config,
             weightDir: weightDir,
-            weightDirURL: weightDirURL
+            weightDirURL: weightDirURL,
+            environment: environment
         )
         return RealModelInferenceEngine(
             config: config,
             weightDirURL: weightDirURL,
             tokenizer: tokenizer,
-            assets: topLevelAssets
+            assets: topLevelAssets,
+            policies: policies
         )
     }
 
@@ -1620,7 +1630,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         case .llama:
             switch Self.selectTrunk(
                 config: config,
-                environment: ProcessInfo.processInfo.environment
+                environment: policies.environment
             ) {
             case .fusedHybrid:
                 do {
@@ -1671,7 +1681,7 @@ public struct RealModelInferenceEngine: ~Copyable {
 
         let remainingContext = config.maxSeq - promptTokens.count
         let effectiveMaxTokens = min(maxTokens, max(remainingContext, 0))
-        let environment = ProcessInfo.processInfo.environment
+        let environment = policies.environment
         if effectiveMaxTokens == 0 {
             let text = tokenizer.decode(promptTokens.map(Int.init))
             let trunk: Trunk?
@@ -1848,7 +1858,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                         onStep: onStep
                     )
                 } catch {
-                    if ProcessInfo.processInfo.environment["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK"] == "1" {
+                    if policies.disableHybridFallback {
                         throw RealModelInferenceError.runtimeFailure("Hybrid speculative fast path failed: \(error)")
                     }
                     fputs(
@@ -1882,7 +1892,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     isCancelled: isCancelled
                 )
             } catch {
-                if ProcessInfo.processInfo.environment["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK"] == "1" {
+                if policies.disableHybridFallback {
                     throw RealModelInferenceError.runtimeFailure("Hybrid fast path failed: \(error)")
                 }
                 useHybridFastPath = false
@@ -4616,7 +4626,8 @@ public struct RealModelInferenceEngine: ~Copyable {
             let newLayers = try Self.compileHybridLayers(
                 config: config,
                 weightDirURL: weightDirURL,
-                maxSeq: bucket
+                maxSeq: bucket,
+                environment: policies.environment
             )
             let newQKNormWeights = try Self.loadHybridLlamaQKNormWeights(
                 config: config,
@@ -4641,7 +4652,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             if newLayers.count > 1,
                Self.usesHybridLayerInputRebinding(
                    architecture: config.architecture,
-                   environment: ProcessInfo.processInfo.environment
+                   environment: policies.environment
                ) {
                 for layerIndex in 1..<newLayers.count {
                     do {
@@ -4745,7 +4756,8 @@ public struct RealModelInferenceEngine: ~Copyable {
             let newLayers = try Self.compileHybridLayers(
                 config: config,
                 weightDirURL: weightDirURL,
-                maxSeq: bucket
+                maxSeq: bucket,
+                environment: policies.environment
             )
             let newQKNormWeights = try Self.loadHybridLlamaQKNormWeights(
                 config: config,
@@ -4773,7 +4785,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             if newLayers.count > 1,
                Self.usesHybridLayerInputRebinding(
                    architecture: config.architecture,
-                   environment: ProcessInfo.processInfo.environment
+                   environment: policies.environment
                ) {
                 for layerIndex in 1..<newLayers.count {
                     do {
@@ -4962,7 +4974,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         // Pre-create cached Metal bindings for all layers (GPT-2 path)
         let cachedBindings: [MetalAttentionKernel.CachedLayerBindings]? = try Self.makeHybridCachedBindingsOrFallback(
             config: config,
-            environment: ProcessInfo.processInfo.environment
+            environment: policies.environment
         ) {
             try compiledHybridSurfaceHandles.map { handles in
                 try metalAttention.createCachedLayerBindings(
@@ -4980,14 +4992,14 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        if ProcessInfo.processInfo.environment["ESPRESSO_REALMODEL_DEBUG_HYBRID_CACHE"] == "1",
+        if policies.debugHybridCacheDumps,
            let firstHandles = compiledHybridSurfaceHandles.first {
             fputs(
                 "[hybrid-surface] qkvIn_row=\(IOSurfaceGetBytesPerRow(firstHandles.qkvIn)) qOut_row=\(IOSurfaceGetBytesPerRow(firstHandles.qOut)) ffnIn_row=\(IOSurfaceGetBytesPerRow(firstHandles.ffnIn)) ffnOut_row=\(IOSurfaceGetBytesPerRow(firstHandles.ffnOut)) laneSpatial=\(firstHandles.laneSpatial) maxSeq=\(firstHandles.maxSeq)\n",
                 stderr
             )
         }
-        let shouldDebugHybridCache = ProcessInfo.processInfo.environment["ESPRESSO_REALMODEL_DEBUG_HYBRID_CACHE"] == "1"
+        let shouldDebugHybridCache = policies.debugHybridCacheDumps
 
         let xCur = TensorBuffer(count: config.dModel, zeroed: true)
         var decodeState: DecodeState
@@ -5024,7 +5036,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     dim: config.dModel,
                     preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                         config: config,
-                        environment: ProcessInfo.processInfo.environment
+                        environment: policies.environment
                     ),
                     readFinalOutputIntoXCur: !useANEGreedyHead,
                     cachedBindings: cachedBindings,
@@ -5183,7 +5195,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     dim: config.dModel,
                     preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                         config: config,
-                        environment: ProcessInfo.processInfo.environment
+                        environment: policies.environment
                     ),
                     readFinalOutputIntoXCur: !useANEGreedyHead,
                     cachedBindings: cachedBindings,
@@ -5652,7 +5664,7 @@ public struct RealModelInferenceEngine: ~Copyable {
     }
 
     private func encodePrompt(_ prompt: String) throws -> [TokenID] {
-        let environment = ProcessInfo.processInfo.environment
+        let environment = policies.environment
         let textToEncode: String
         // CLI `preparedGeneratePrompt` may already apply the same wrap.
         if environment["ESPRESSO_RAW_PROMPT"] == "1" || prompt.hasPrefix("<|im_start|>") {
@@ -6003,7 +6015,7 @@ public struct RealModelInferenceEngine: ~Copyable {
 
         if try Self.resolvedTrunk(
             config: config,
-            environment: ProcessInfo.processInfo.environment
+            environment: policies.environment
         ) == .exactCPU {
             return try generateIncrementalExactCPULlama(
                 promptTokens: promptTokens,
@@ -6025,7 +6037,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         // Pre-create cached decode-surface metadata for all layers.
         let cachedBindings: [MetalAttentionKernel.CachedLayerBindings]? = try Self.makeHybridCachedBindingsOrFallback(
             config: config,
-            environment: ProcessInfo.processInfo.environment
+            environment: policies.environment
         ) {
             try compiledHybridSurfaceHandles.map { handles in
                 try metalAttention.createCachedLayerBindings(
@@ -6169,7 +6181,7 @@ public struct RealModelInferenceEngine: ~Copyable {
 
         let useCPUExactQKV = Self.prefersCPUExactQKV(
             config: config,
-            environment: ProcessInfo.processInfo.environment
+            environment: policies.environment
         )
         let cpuExactQKVLayerWeights: [LlamaCPUQKVWeights]? = if useCPUExactQKV {
             try (0..<config.nLayer).map { layerIndex in
@@ -6304,7 +6316,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     headDim: headDim,
                     preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                         config: config,
-                        environment: ProcessInfo.processInfo.environment
+                        environment: policies.environment
                     ),
                     qkvOverride: cpuExactQKV,
                     postQKVHook: metalRoPEConfig != nil ? nil : ropeHook,
@@ -6453,7 +6465,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     headDim: headDim,
                     preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                         config: config,
-                        environment: ProcessInfo.processInfo.environment
+                        environment: policies.environment
                     ),
                     qkvOverride: cpuExactQKV,
                     postQKVHook: metalRoPEConfig != nil ? nil : ropeHook,
@@ -6861,12 +6873,13 @@ public struct RealModelInferenceEngine: ~Copyable {
         config: MultiModelConfig,
         weightDirURL: URL,
         sourceLayerRange: Range<Int>? = nil,
-        maxSeq: Int
+        maxSeq: Int,
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> LayerStorage<HybridDecodeKernelSet> {
         let layerRange = sourceLayerRange ?? (0..<config.nLayer)
         let useDonorDelta = supportsHybridDonorDelta(
             config: config,
-            environment: ProcessInfo.processInfo.environment
+            environment: environment
         )
         var donorHexIDs: HybridDecodeKernelSet.DonorHexIDs? = nil
         return try LayerStorage<HybridDecodeKernelSet>(count: layerRange.count, throwingInitializer: { localLayerIndex in
@@ -8722,7 +8735,7 @@ public struct RealModelInferenceEngine: ~Copyable {
 
     private mutating func exactClassifierArgmax(_ hidden: [Float]) -> Int {
         precondition(hidden.count == config.dModel)
-        if let dumpPath = ProcessInfo.processInfo.environment["ESPRESSO_DUMP_LM_HEAD_HIDDEN"],
+        if let dumpPath = policies.lmHeadHiddenDumpPath,
            !dumpPath.isEmpty {
             Self.appendLMHeadHiddenDump(hidden, to: dumpPath)
         }


### PR DESCRIPTION
## What

The engine's effective interface used to be three build parameters plus ~78 undeclared environment variables read lazily mid-flight. Now one dictionary crosses the seam at build time:

1. **`EnginePolicies`** (new, `Sources/RealModelInference/EnginePolicies.swift`): immutable value resolved once from a single dictionary. Holds the frozen snapshot that feeds the pure `(config:environment:)` policy functions, plus typed fields for knobs consulted on hot or failure paths (`disableHybridFallback`, `debugHybridCacheDumps`, `lmHeadHiddenDumpPath`).

2. **`build(config:weightDir:tokenizerDir:environment:)`** takes the dictionary as a parameter — only its default touches live process state. The engine stores policies; instance paths never read `ProcessInfo` again.

3. **All serving-path reads switch to policies**: trunk selection in `precompileHybridDecode`/`generate`/`generateIncrementalHybridLlama`, cached-binding fallbacks, CPU-decode-attention preferences, RoPE hooks, donor-delta compile decisions, speculative fallback gates, classifier argmax dumps.

4. **`ESPRuntimeRunner` passes manifest metadata as parameters** (merged into the environment dict handed to `build`); `withTemporaryEnvironment`/`setenv` is deleted from the runtime. Bundle output-head and draft metadata still travel under their keys, but across an explicit parameter instead of process-global mutation.

Remaining `ProcessInfo` reads are static test-only surfaces: single-layer probes, the token-suite hook (scheduled for deletion by the locked llama-serving-session decision), and the `ANE_HARDWARE_TESTS` gate.

## Why

- **Interface honesty:** callers see one parameter instead of an undeclared env contract with a "setenv before generate" ordering constraint.
- **Testability:** behavior is steered by constructing dictionaries, not mutating process globals.
- **Locality:** resolution happens at exactly one point; mid-generation environment changes can no longer flip trunk/policy decisions between tokens.

## Deliberately out of scope

- Kernel-set compile-time env defaults (`ESPRESSO_DISABLE_HYBRID_FUSED_POST_ATTENTION`, `ESPRESSO_DECODE_LANE_SPATIAL`, ...) — compile-once, not hot-path; natural follow-up is an options value threaded from policies.
- `DecodeRuntimeOptions` statics in DecodeForwardPass (shared with the harness lane).
- CLI-side env seeding for compile-cache policy (ANE layer, not engine policy).

## Verification

- `swift build` green
- `swift test`: 540 executed, 0 failures (169 hardware-gated skips), identical to baseline
- All 6 ESPRuntimeTests pass, including the cpuSafe fallback path whose `ESPRESSO_USE_CPU_EXACT_DECODE` override now flows through the parameter
- Grep proof: zero live-process reads remain on serving paths

Stacked on #32 (which is stacked on #31); merge order matters only for conflict-free review.
