### PR TITLE
T3: compiler-checked CompiledReadiness, merged ensure twins, presence-typed heads

### DIFF
--- a/Sources/Espresso/GenerationHarness.swift
+++ b/Sources/Espresso/GenerationHarness.swift
@@ -21,6 +21,36 @@ public enum RecurrentGenerationTrunkBackend: Sendable {
     case identityZeroTrunk
 }
 
+/// Presence-typed output-head selection: the compiled head itself carries which
+/// backend it serves, so requesting token selection against an uncompiled
+/// backend is unrepresentable instead of a runtime throw.
+///
+/// Replaces the former parallel `outputHeadBackend`-plus-three-optional-heads
+/// state whose mismatch produced "backend requested without compiled head"
+/// failures at every use site.
+enum GenerationOutputHeadSelection {
+    /// CPU-classifier backends (`cpu`, `cpuThenANE`, `cpuPartitionedArgmax`,
+    /// `cpuFP16Tiled`) that classify over the FP32 classifier weights; carries
+    /// the exact backend for deferred-head and tiled-argmax routing.
+    case cpuSgemm(GenerationOutputHeadBackend)
+    /// Staged or clustered exact-CPU head — identical post-construction.
+    case stagedCPU(CPUStagedExactGenerationOutputHead)
+    case aneClassifier(ANEGenerationClassifierHead)
+    case aneRMSNormClassifier(ANEGenerationRMSNormClassifierHead)
+
+    /// Backend this selection was constructed from. Staged and clustered
+    /// backends are indistinguishable after construction; both report as
+    /// `.cpuExactStaged`.
+    var backend: GenerationOutputHeadBackend {
+        switch self {
+        case .cpuSgemm(let backend): backend
+        case .stagedCPU: .cpuExactStaged
+        case .aneClassifier: .aneClassifier
+        case .aneRMSNormClassifier: .aneRMSNormClassifier
+        }
+    }
+}
+
 public struct GenerationPerformanceSnapshot: Sendable, Equatable {
     public let compileTimeMs: Double
     public let trunkLatencyMs: Double
@@ -892,13 +922,14 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
     private let currentProposalActivation: TensorBuffer
     private let stepRMSWorkspace: RMSNorm.Workspace
     private let futureRMSWorkspace: RMSNorm.Workspace
-    private let outputHeadBackend: GenerationOutputHeadBackend
-    private let futureOutputHeadBackend: GenerationOutputHeadBackend
+    /// Current-side output head, presence-typed against its backend.
+    private let outputHead: GenerationOutputHeadSelection
+    /// Future-proposer output head, presence-typed against its backend
+    /// (`.cpuSgemm(.cpu)` when this model has no future proposer).
+    private let futureOutputHead: GenerationOutputHeadSelection
+    private var outputHeadBackend: GenerationOutputHeadBackend { outputHead.backend }
+    private var futureOutputHeadBackend: GenerationOutputHeadBackend { futureOutputHead.backend }
     private let trunkBackend: RecurrentGenerationTrunkBackend
-    private let aneClassifierHead: ANEGenerationClassifierHead?
-    private let aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
-    private let futureANEClassifierHead: ANEGenerationClassifierHead?
-    private let futureANERMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
     private let sharedOutputHeadWeights: SharedReadOnlyOutputHeadWeights
     private var twoStepSessions: LayerStorage<RWKVStyleTwoStepRecurrentSession>
     private var fusedPairTwoStepSessions: LayerStorage<RWKVStyleFusedTwoLayerTwoStepSession>
@@ -1091,89 +1122,80 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
             hasFutureProposer = false
         }
 
-        let aneClassifierHead: ANEGenerationClassifierHead?
+        let outputHead: GenerationOutputHeadSelection
         switch outputHeadBackend {
         case .aneClassifier:
             do {
                 if sharedClassifier {
-                    aneClassifierHead = try ANEGenerationClassifierHead(
+                    outputHead = .aneClassifier(try ANEGenerationClassifierHead(
                         classifierWeights: embedding,
                         vocabSize: vocabSize,
                         laneSpatial: outputHeadLaneSpatial
-                    )
+                    ))
                 } else {
-                    aneClassifierHead = try ANEGenerationClassifierHead(
+                    outputHead = .aneClassifier(try ANEGenerationClassifierHead(
                         classifierWeights: classifier,
                         vocabSize: vocabSize,
                         laneSpatial: outputHeadLaneSpatial
-                    )
+                    ))
                 }
             } catch {
                 throw .runtimeFailure("two-step ANE classifier setup failed: \(error)")
             }
-        default:
-            aneClassifierHead = nil
-        }
-
-        let aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
-        switch outputHeadBackend {
         case .aneRMSNormClassifier:
             do {
                 if sharedClassifier {
-                    aneRMSNormClassifierHead = try ANEGenerationRMSNormClassifierHead(
+                    outputHead = .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                         rmsFinal: rmsFinal,
                         classifierWeights: embedding,
                         vocabSize: vocabSize,
                         laneSpatial: outputHeadLaneSpatial
-                    )
+                    ))
                 } else {
-                    aneRMSNormClassifierHead = try ANEGenerationRMSNormClassifierHead(
+                    outputHead = .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                         rmsFinal: rmsFinal,
                         classifierWeights: classifier,
                         vocabSize: vocabSize,
                         laneSpatial: outputHeadLaneSpatial
-                    )
+                    ))
                 }
             } catch {
                 throw .runtimeFailure("two-step ANE fused output-head setup failed: \(error)")
             }
-        default:
-            aneRMSNormClassifierHead = nil
+        case .cpuExactStaged, .cpuExactClustered:
+            // Also rejected up front before any session compilation; unreachable here.
+            throw .invalidArguments("two-step branch-state promotion model does not support staged CPU output heads")
+        case .cpu, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+            outputHead = .cpuSgemm(outputHeadBackend)
         }
 
-        let futureOutputHeadBackend: GenerationOutputHeadBackend = hasFutureProposer ? outputHeadBackend : .cpu
+        let futureOutputHeadBackend = hasFutureProposer ? outputHeadBackend : .cpu
 
-        let futureANEClassifierHead: ANEGenerationClassifierHead?
+        let futureOutputHead: GenerationOutputHeadSelection
         switch futureOutputHeadBackend {
         case .aneClassifier:
             do {
-                futureANEClassifierHead = try ANEGenerationClassifierHead(
+                futureOutputHead = .aneClassifier(try ANEGenerationClassifierHead(
                     classifierWeights: futureClassifier,
                     vocabSize: vocabSize,
                     laneSpatial: Self.futureProposerOutputHeadLaneSpatial
-                )
+                ))
             } catch {
                 throw .runtimeFailure("two-step ANE future proposer setup failed: \(error)")
             }
-        default:
-            futureANEClassifierHead = nil
-        }
-
-        let futureANERMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
-        switch futureOutputHeadBackend {
         case .aneRMSNormClassifier:
             do {
-                futureANERMSNormClassifierHead = try ANEGenerationRMSNormClassifierHead(
+                futureOutputHead = .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                     rmsFinal: futureRMS,
                     classifierWeights: futureClassifier,
                     vocabSize: vocabSize,
                     laneSpatial: Self.futureProposerOutputHeadLaneSpatial
-                )
+                ))
             } catch {
                 throw .runtimeFailure("two-step ANE future proposer setup failed: \(error)")
             }
-        default:
-            futureANERMSNormClassifierHead = nil
+        case .cpuExactStaged, .cpuExactClustered, .cpu, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+            futureOutputHead = .cpuSgemm(futureOutputHeadBackend)
         }
 
         self.vocabSize = vocabSize
@@ -1198,13 +1220,9 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
         self.currentProposalActivation = TensorBuffer(count: ModelConfig.dim, zeroed: true)
         self.stepRMSWorkspace = RMSNorm.Workspace(seqLen: 1)
         self.futureRMSWorkspace = RMSNorm.Workspace(seqLen: 1)
-        self.outputHeadBackend = outputHeadBackend
-        self.futureOutputHeadBackend = futureOutputHeadBackend
         self.trunkBackend = trunkBackend
-        self.aneClassifierHead = aneClassifierHead
-        self.aneRMSNormClassifierHead = aneRMSNormClassifierHead
-        self.futureANEClassifierHead = futureANEClassifierHead
-        self.futureANERMSNormClassifierHead = futureANERMSNormClassifierHead
+        self.outputHead = outputHead
+        self.futureOutputHead = futureOutputHead
         self.sharedOutputHeadWeights = sharedOutputHeadWeights
         self.twoStepSessions = twoStepSessions
         self.fusedPairTwoStepSessions = fusedPairTwoStepSessions
@@ -1364,15 +1382,13 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
             let exactNextToken = try Self.selectTokenFromActivation(
                 pair0ActivationA,
                 strategy: strategy,
-                outputHeadBackend: outputHeadBackend,
+                outputHead: outputHead,
                 rmsFinal: rmsFinal,
                 stepNorm: stepNorm,
                 stepLogits: stepLogits,
                 embedding: embedding,
                 classifier: classifier,
                 sharedClassifier: sharedClassifier,
-                aneClassifierHead: aneClassifierHead,
-                aneRMSNormClassifierHead: aneRMSNormClassifierHead,
                 vocabSize: vocabSize,
                 stepRMSWorkspace: stepRMSWorkspace
             )
@@ -1527,15 +1543,13 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
                 pair0ActivationA,
                 pair1ActivationA,
                 strategy: strategy,
-                outputHeadBackend: outputHeadBackend,
+                outputHead: outputHead,
                 rmsFinal: rmsFinal,
                 stepNorm: stepNorm,
                 stepLogits: stepLogits,
                 embedding: embedding,
                 classifier: classifier,
                 sharedClassifier: sharedClassifier,
-                aneClassifierHead: aneClassifierHead,
-                aneRMSNormClassifierHead: aneRMSNormClassifierHead,
                 vocabSize: vocabSize,
                 stepRMSWorkspace: stepRMSWorkspace
             )
@@ -1544,15 +1558,13 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
                 pair0ActivationB,
                 pair1ActivationB,
                 strategy: strategy,
-                outputHeadBackend: outputHeadBackend,
+                outputHead: outputHead,
                 rmsFinal: rmsFinal,
                 stepNorm: stepNorm,
                 stepLogits: stepLogits,
                 embedding: embedding,
                 classifier: classifier,
                 sharedClassifier: sharedClassifier,
-                aneClassifierHead: aneClassifierHead,
-                aneRMSNormClassifierHead: aneRMSNormClassifierHead,
                 vocabSize: vocabSize,
                 stepRMSWorkspace: stepRMSWorkspace
             )
@@ -1630,15 +1642,13 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
         return try Self.selectTokenFromActivation(
             currentProposalActivation,
             strategy: strategy,
-            outputHeadBackend: futureOutputHeadBackend,
+            outputHead: futureOutputHead,
             rmsFinal: futureRMS,
             stepNorm: futureNorm,
             stepLogits: futureLogits,
             embedding: embedding,
             classifier: futureClassifier,
             sharedClassifier: false,
-            aneClassifierHead: futureANEClassifierHead,
-            aneRMSNormClassifierHead: futureANERMSNormClassifierHead,
             vocabSize: vocabSize,
             stepRMSWorkspace: futureRMSWorkspace
         )
@@ -1689,21 +1699,20 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
 
     private static func selectTokenFromActivation(
         _ activation: borrowing TensorBuffer,
-        strategy: TokenSelectionStrategy
-        ,
-        outputHeadBackend: GenerationOutputHeadBackend,
+        strategy: TokenSelectionStrategy,
+        outputHead: GenerationOutputHeadSelection,
         rmsFinal: borrowing TensorBuffer,
         stepNorm: borrowing TensorBuffer,
         stepLogits: borrowing TensorBuffer,
         embedding: borrowing TensorBuffer,
         classifier: borrowing TensorBuffer,
         sharedClassifier: Bool,
-        aneClassifierHead: ANEGenerationClassifierHead?,
-        aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?,
         vocabSize: Int,
         stepRMSWorkspace: borrowing RMSNorm.Workspace
     ) throws(GenerationError) -> TokenID {
-        if outputHeadBackend != .aneRMSNormClassifier {
+        // The fused head applies RMSNorm internally over the raw activation;
+        // every other route classifies the normalized activation.
+        if outputHead.backend != .aneRMSNormClassifier {
             activation.withUnsafePointer { xPtr in
                 stepNorm.withUnsafeMutablePointer { normPtr in
                     rmsFinal.withUnsafePointer { rmsPtr in
@@ -1721,8 +1730,8 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
         }
 
         let token: TokenID
-        switch outputHeadBackend {
-        case .cpu:
+        switch outputHead {
+        case .cpuSgemm:
             // beta=0.0 means sgemm overwrites C entirely — no pre-zeroing needed
             stepLogits.withUnsafeMutablePointer { logitsPtr in
                 classifierPointer(
@@ -1751,47 +1760,15 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
                 }
             }
             token = try selectToken(from: stepLogits, strategy: strategy)
-        case .aneClassifier:
-            guard let aneClassifierHead else {
-                throw .runtimeFailure("two-step ANE classifier backend requested without compiled head")
-            }
-            token = try aneClassifierHead.selectArgmax(normalizedInput: stepNorm)
-        case .aneRMSNormClassifier:
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("two-step ANE fused output-head backend requested without compiled head")
-            }
-            token = try aneRMSNormClassifierHead.selectArgmax(rawInput: activation)
-        case .cpuExactStaged, .cpuExactClustered:
+        case .stagedCPU:
+            // The two-step initializer rejects staged CPU heads up front, so a
+            // staged selection cannot reach this model; keep the capability
+            // boundary explicit rather than guessing a route.
             throw .runtimeFailure("two-step branch-state promotion model does not support staged CPU output heads")
-        case .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            // Fall through to CPU sgemm path for now
-            stepLogits.withUnsafeMutablePointer { logitsPtr in
-                classifierPointer(
-                    sharedClassifier: sharedClassifier,
-                    embedding: embedding,
-                    classifier: classifier
-                ) { clsPtr in
-                    stepNorm.withUnsafePointer { normPtr in
-                        BLAS.sgemm(
-                            CblasRowMajor,
-                            CblasNoTrans,
-                            CblasNoTrans,
-                            m: Int32(vocabSize),
-                            n: 1,
-                            k: Int32(ModelConfig.dim),
-                            alpha: 1.0,
-                            a: clsPtr,
-                            lda: Int32(ModelConfig.dim),
-                            b: normPtr,
-                            ldb: 1,
-                            beta: 0.0,
-                            c: logitsPtr,
-                            ldc: 1
-                        )
-                    }
-                }
-            }
-            token = try selectToken(from: stepLogits, strategy: strategy)
+        case .aneClassifier(let head):
+            token = try head.selectArgmax(normalizedInput: stepNorm)
+        case .aneRMSNormClassifier(let head):
+            token = try head.selectArgmax(rawInput: activation)
         }
 
         return token
@@ -1801,56 +1778,50 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
         _ activationA: borrowing TensorBuffer,
         _ activationB: borrowing TensorBuffer,
         strategy: TokenSelectionStrategy,
-        outputHeadBackend: GenerationOutputHeadBackend,
+        outputHead: GenerationOutputHeadSelection,
         rmsFinal: borrowing TensorBuffer,
         stepNorm: borrowing TensorBuffer,
         stepLogits: borrowing TensorBuffer,
         embedding: borrowing TensorBuffer,
         classifier: borrowing TensorBuffer,
         sharedClassifier: Bool,
-        aneClassifierHead: ANEGenerationClassifierHead?,
-        aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?,
         vocabSize: Int,
         stepRMSWorkspace: borrowing RMSNorm.Workspace
     ) throws(GenerationError) -> (TokenID, TokenID) {
-        if outputHeadBackend == .aneRMSNormClassifier {
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("two-step ANE fused output-head backend requested without compiled head")
-            }
-            return try aneRMSNormClassifierHead.selectArgmaxPair(
+        switch outputHead {
+        case .aneRMSNormClassifier(let head):
+            return try head.selectArgmaxPair(
                 rawInputA: activationA,
                 rawInputB: activationB
             )
+        case .cpuSgemm, .stagedCPU, .aneClassifier:
+            break
         }
 
         return (
             try Self.selectTokenFromActivation(
                 activationA,
                 strategy: strategy,
-                outputHeadBackend: outputHeadBackend,
+                outputHead: outputHead,
                 rmsFinal: rmsFinal,
                 stepNorm: stepNorm,
                 stepLogits: stepLogits,
                 embedding: embedding,
                 classifier: classifier,
                 sharedClassifier: sharedClassifier,
-                aneClassifierHead: aneClassifierHead,
-                aneRMSNormClassifierHead: aneRMSNormClassifierHead,
                 vocabSize: vocabSize,
                 stepRMSWorkspace: stepRMSWorkspace
             ),
             try Self.selectTokenFromActivation(
                 activationB,
                 strategy: strategy,
-                outputHeadBackend: outputHeadBackend,
+                outputHead: outputHead,
                 rmsFinal: rmsFinal,
                 stepNorm: stepNorm,
                 stepLogits: stepLogits,
                 embedding: embedding,
                 classifier: classifier,
                 sharedClassifier: sharedClassifier,
-                aneClassifierHead: aneClassifierHead,
-                aneRMSNormClassifierHead: aneRMSNormClassifierHead,
                 vocabSize: vocabSize,
                 stepRMSWorkspace: stepRMSWorkspace
             )
@@ -2114,10 +2085,9 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
     private let verifyLogits: TensorBuffer
     private let stepRMSWorkspace: RMSNorm.Workspace
     private let verifyRMSWorkspace: RMSNorm.Workspace
-    private let outputHeadBackend: GenerationOutputHeadBackend
-    private let cpuExactStagedHead: CPUStagedExactGenerationOutputHead?
-    private let aneClassifierHead: ANEGenerationClassifierHead?
-    private let aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
+    /// Output head, presence-typed against its backend.
+    private let outputHead: GenerationOutputHeadSelection
+    private var outputHeadBackend: GenerationOutputHeadBackend { outputHead.backend }
     private var decodeHandles: [DecodeSurfaceHandles]
     private var inferenceHandles: [InferenceSurfaceHandles]
     private var decodeState: DecodeState
@@ -2170,21 +2140,7 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
         let classifier = sharedClassifier
             ? TensorBuffer(count: 0, zeroed: true)
             : GenerationWeightCloner.cloneTensor(weights.classifier)
-        let aneClassifierHead = try Self.makeANEClassifierHead(
-            outputHeadBackend: outputHeadBackend,
-            vocabSize: vocabSize,
-            sharedClassifier: sharedClassifier,
-            embedding: embedding,
-            classifier: classifier
-        )
-        let cpuExactStagedHead = try Self.makeCPUExactStagedHead(
-            outputHeadBackend: outputHeadBackend,
-            vocabSize: vocabSize,
-            sharedClassifier: sharedClassifier,
-            embedding: embedding,
-            classifier: classifier
-        )
-        let aneRMSNormClassifierHead = try Self.makeANERMSNormClassifierHead(
+        let outputHead = try Self.makeOutputHead(
             outputHeadBackend: outputHeadBackend,
             vocabSize: vocabSize,
             sharedClassifier: sharedClassifier,
@@ -2220,10 +2176,7 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
         self.verifyLogits = TensorBuffer(count: vocabSize * ModelConfig.seqLen, zeroed: true)
         self.stepRMSWorkspace = RMSNorm.Workspace(seqLen: 1)
         self.verifyRMSWorkspace = RMSNorm.Workspace(seqLen: ModelConfig.seqLen)
-        self.outputHeadBackend = outputHeadBackend
-        self.cpuExactStagedHead = cpuExactStagedHead
-        self.aneClassifierHead = aneClassifierHead
-        self.aneRMSNormClassifierHead = aneRMSNormClassifierHead
+        self.outputHead = outputHead
         self.decodeHandles = decodeHandles
         self.inferenceHandles = inferenceHandles
         self.decodeState = decodeState
@@ -2316,89 +2269,70 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
         }
     }
 
-    private static func makeANEClassifierHead(
-        outputHeadBackend: GenerationOutputHeadBackend,
-        vocabSize: Int,
-        sharedClassifier: Bool,
-        embedding: borrowing TensorBuffer,
-        classifier: borrowing TensorBuffer
-    ) throws(GenerationError) -> ANEGenerationClassifierHead? {
-        switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
-        case .aneClassifier:
-            if sharedClassifier {
-                return try ANEGenerationClassifierHead(classifierWeights: embedding, vocabSize: vocabSize)
-            }
-            return try ANEGenerationClassifierHead(classifierWeights: classifier, vocabSize: vocabSize)
-        case .aneRMSNormClassifier:
-            return nil
-        }
-    }
-
-    private static func makeCPUExactStagedHead(
-        outputHeadBackend: GenerationOutputHeadBackend,
-        vocabSize: Int,
-        sharedClassifier: Bool,
-        embedding: borrowing TensorBuffer,
-        classifier: borrowing TensorBuffer
-    ) throws(GenerationError) -> CPUStagedExactGenerationOutputHead? {
-        switch outputHeadBackend {
-        case .cpu, .aneClassifier, .aneRMSNormClassifier, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
-        case .cpuExactStaged:
-            if sharedClassifier {
-                return try CPUStagedExactGenerationOutputHead(
-                    classifierWeights: embedding,
-                    vocabSize: vocabSize,
-                    layoutStrategy: .contiguous(shardSize: 1024)
-                )
-            }
-            return try CPUStagedExactGenerationOutputHead(
-                classifierWeights: classifier,
-                vocabSize: vocabSize,
-                layoutStrategy: .contiguous(shardSize: 1024)
-            )
-        case .cpuExactClustered:
-            if sharedClassifier {
-                return try CPUStagedExactGenerationOutputHead(
-                    classifierWeights: embedding,
-                    vocabSize: vocabSize,
-                    layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
-                )
-            }
-            return try CPUStagedExactGenerationOutputHead(
-                classifierWeights: classifier,
-                vocabSize: vocabSize,
-                layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
-            )
-        }
-    }
-
-    private static func makeANERMSNormClassifierHead(
+    /// Compiles exactly the output head the requested backend needs; the
+    /// returned selection is presence-typed, so consumers never face a
+    /// backend whose head failed to exist.
+    private static func makeOutputHead(
         outputHeadBackend: GenerationOutputHeadBackend,
         vocabSize: Int,
         sharedClassifier: Bool,
         rmsFinal: borrowing TensorBuffer,
         embedding: borrowing TensorBuffer,
         classifier: borrowing TensorBuffer
-    ) throws(GenerationError) -> ANEGenerationRMSNormClassifierHead? {
+    ) throws(GenerationError) -> GenerationOutputHeadSelection {
         switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .aneClassifier, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
+        case .cpu, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+            return .cpuSgemm(outputHeadBackend)
+        case .aneClassifier:
+            if sharedClassifier {
+                return .aneClassifier(try ANEGenerationClassifierHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize
+                ))
+            }
+            return .aneClassifier(try ANEGenerationClassifierHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize
+            ))
         case .aneRMSNormClassifier:
             if sharedClassifier {
-                return try ANEGenerationRMSNormClassifierHead(
+                return .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                     rmsFinal: rmsFinal,
                     classifierWeights: embedding,
                     vocabSize: vocabSize
-                )
+                ))
             }
-            return try ANEGenerationRMSNormClassifierHead(
+            return .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                 rmsFinal: rmsFinal,
                 classifierWeights: classifier,
                 vocabSize: vocabSize
-            )
+            ))
+        case .cpuExactStaged:
+            if sharedClassifier {
+                return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize,
+                    layoutStrategy: .contiguous(shardSize: 1024)
+                ))
+            }
+            return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize,
+                layoutStrategy: .contiguous(shardSize: 1024)
+            ))
+        case .cpuExactClustered:
+            if sharedClassifier {
+                return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize,
+                    layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
+                ))
+            }
+            return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize,
+                layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
+            ))
         }
     }
 
@@ -2562,8 +2496,10 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
         }
 
         stepLogits.zero()
-        switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+        switch outputHead {
+        case .cpuSgemm, .stagedCPU:
+            // Full-logits projection always runs the FP32 classifier, even for
+            // staged heads: they only accelerate argmax selection.
             stepLogits.withUnsafeMutablePointer { logitsPtr in
                 classifierPointer { clsPtr in
                     stepNorm.withUnsafePointer { normPtr in
@@ -2586,16 +2522,10 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
                     }
                 }
             }
-        case .aneClassifier:
-            guard let aneClassifierHead else {
-                throw .runtimeFailure("ANE classifier backend requested without compiled head")
-            }
-            try aneClassifierHead.project(normalizedInput: stepNorm, logits: stepLogits)
-        case .aneRMSNormClassifier:
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("ANE fused output-head backend requested without compiled head")
-            }
-            try aneRMSNormClassifierHead.project(rawInput: xCur, logits: stepLogits)
+        case .aneClassifier(let head):
+            try head.project(normalizedInput: stepNorm, logits: stepLogits)
+        case .aneRMSNormClassifier(let head):
+            try head.project(rawInput: xCur, logits: stepLogits)
         }
 
         logitsLatencyMs += GenerationClock.milliseconds(start: logitsStart, end: GenerationClock.now())
@@ -2624,8 +2554,11 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
         }
 
         let token: TokenID
-        switch outputHeadBackend {
-        case .cpu:
+        switch outputHead {
+        case .cpuSgemm:
+            // Every CPU-classifier backend (including deferred and tiled
+            // variants) classifies via sgemm in this model.
+            // beta=0.0 means sgemm overwrites C entirely — no pre-zeroing needed
             stepLogits.zero()
             stepLogits.withUnsafeMutablePointer { logitsPtr in
                 classifierPointer { clsPtr in
@@ -2650,52 +2583,12 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
                 }
             }
             token = try selectToken(from: stepLogits, strategy: strategy)
-        case .cpuExactStaged:
-            guard let cpuExactStagedHead else {
-                throw .runtimeFailure("staged exact CPU output head requested without staged head")
-            }
-            token = try cpuExactStagedHead.selectArgmax(normalizedInput: stepNorm)
-        case .cpuExactClustered:
-            guard let cpuExactStagedHead else {
-                throw .runtimeFailure("clustered exact CPU output head requested without staged head")
-            }
-            token = try cpuExactStagedHead.selectArgmax(normalizedInput: stepNorm)
-        case .aneClassifier:
-            guard let aneClassifierHead else {
-                throw .runtimeFailure("ANE classifier backend requested without compiled head")
-            }
-            token = try aneClassifierHead.selectArgmax(normalizedInput: stepNorm)
-        case .aneRMSNormClassifier:
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("ANE fused output-head backend requested without compiled head")
-            }
-            token = try aneRMSNormClassifierHead.selectArgmax(rawInput: xCur)
-        case .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            // Fall through to CPU sgemm path
-            stepLogits.zero()
-            stepLogits.withUnsafeMutablePointer { logitsPtr in
-                classifierPointer { clsPtr in
-                    stepNorm.withUnsafePointer { normPtr in
-                        BLAS.sgemm(
-                            CblasRowMajor,
-                            CblasNoTrans,
-                            CblasNoTrans,
-                            m: Int32(vocabSize),
-                            n: 1,
-                            k: Int32(ModelConfig.dim),
-                            alpha: 1.0,
-                            a: clsPtr,
-                            lda: Int32(ModelConfig.dim),
-                            b: normPtr,
-                            ldb: 1,
-                            beta: 0.0,
-                            c: logitsPtr,
-                            ldc: 1
-                        )
-                    }
-                }
-            }
-            token = try selectToken(from: stepLogits, strategy: strategy)
+        case .stagedCPU(let head):
+            token = try head.selectArgmax(normalizedInput: stepNorm)
+        case .aneClassifier(let head):
+            token = try head.selectArgmax(normalizedInput: stepNorm)
+        case .aneRMSNormClassifier(let head):
+            token = try head.selectArgmax(rawInput: xCur)
         }
 
         logitsLatencyMs += GenerationClock.milliseconds(start: logitsStart, end: GenerationClock.now())
@@ -2781,10 +2674,9 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
     private let stepNorm: TensorBuffer
     private let stepLogits: TensorBuffer
     private let stepRMSWorkspace: RMSNorm.Workspace
-    private let outputHeadBackend: GenerationOutputHeadBackend
-    private let cpuExactStagedHead: CPUStagedExactGenerationOutputHead?
-    private let aneClassifierHead: ANEGenerationClassifierHead?
-    private let aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
+    /// Output head, presence-typed against its backend.
+    private let outputHead: GenerationOutputHeadSelection
+    private var outputHeadBackend: GenerationOutputHeadBackend { outputHead.backend }
     private let sharedOutputHeadWeights: SharedReadOnlyOutputHeadWeights
     private var activationA: TensorBuffer
     private var activationB: TensorBuffer
@@ -2880,22 +2772,7 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
             : (shareReadOnlyWeights
                 ? GenerationWeightCloner.shareTensor(sharedOutputHeadWeights.classifier)
                 : GenerationWeightCloner.cloneTensor(weights.classifier))
-        let aneClassifierHead = try Self.makeANEClassifierHead(
-            outputHeadBackend: outputHeadBackend,
-            vocabSize: vocabSize,
-            sharedClassifier: sharedClassifier,
-            embedding: embedding,
-            classifier: classifier,
-            laneSpatial: outputHeadLaneSpatial
-        )
-        let cpuExactStagedHead = try Self.makeCPUExactStagedHead(
-            outputHeadBackend: outputHeadBackend,
-            vocabSize: vocabSize,
-            sharedClassifier: sharedClassifier,
-            embedding: embedding,
-            classifier: classifier
-        )
-        let aneRMSNormClassifierHead = try Self.makeANERMSNormClassifierHead(
+        let outputHead = try Self.makeOutputHead(
             outputHeadBackend: outputHeadBackend,
             vocabSize: vocabSize,
             sharedClassifier: sharedClassifier,
@@ -2993,10 +2870,7 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
         self.stepNorm = TensorBuffer(count: ModelConfig.dim, zeroed: true)
         self.stepLogits = TensorBuffer(count: vocabSize, zeroed: true)
         self.stepRMSWorkspace = RMSNorm.Workspace(seqLen: 1)
-        self.outputHeadBackend = outputHeadBackend
-        self.cpuExactStagedHead = cpuExactStagedHead
-        self.aneClassifierHead = aneClassifierHead
-        self.aneRMSNormClassifierHead = aneRMSNormClassifierHead
+        self.outputHead = outputHead
         self.sharedOutputHeadWeights = sharedOutputHeadWeights
         self.activationA = TensorBuffer(count: ModelConfig.dim, zeroed: true)
         self.activationB = TensorBuffer(count: ModelConfig.dim, zeroed: true)
@@ -3088,75 +2962,10 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
         }
     }
 
-    private static func makeANEClassifierHead(
-        outputHeadBackend: GenerationOutputHeadBackend,
-        vocabSize: Int,
-        sharedClassifier: Bool,
-        embedding: borrowing TensorBuffer,
-        classifier: borrowing TensorBuffer,
-        laneSpatial: Int
-    ) throws(GenerationError) -> ANEGenerationClassifierHead? {
-        switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
-        case .aneClassifier:
-            if sharedClassifier {
-                return try ANEGenerationClassifierHead(
-                    classifierWeights: embedding,
-                    vocabSize: vocabSize,
-                    laneSpatial: laneSpatial
-                )
-            }
-            return try ANEGenerationClassifierHead(
-                classifierWeights: classifier,
-                vocabSize: vocabSize,
-                laneSpatial: laneSpatial
-            )
-        case .aneRMSNormClassifier:
-            return nil
-        }
-    }
-
-    private static func makeCPUExactStagedHead(
-        outputHeadBackend: GenerationOutputHeadBackend,
-        vocabSize: Int,
-        sharedClassifier: Bool,
-        embedding: borrowing TensorBuffer,
-        classifier: borrowing TensorBuffer
-    ) throws(GenerationError) -> CPUStagedExactGenerationOutputHead? {
-        switch outputHeadBackend {
-        case .cpu, .aneClassifier, .aneRMSNormClassifier, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
-        case .cpuExactStaged:
-            if sharedClassifier {
-                return try CPUStagedExactGenerationOutputHead(
-                    classifierWeights: embedding,
-                    vocabSize: vocabSize,
-                    layoutStrategy: .contiguous(shardSize: 1024)
-                )
-            }
-            return try CPUStagedExactGenerationOutputHead(
-                classifierWeights: classifier,
-                vocabSize: vocabSize,
-                layoutStrategy: .contiguous(shardSize: 1024)
-            )
-        case .cpuExactClustered:
-            if sharedClassifier {
-                return try CPUStagedExactGenerationOutputHead(
-                    classifierWeights: embedding,
-                    vocabSize: vocabSize,
-                    layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
-                )
-            }
-            return try CPUStagedExactGenerationOutputHead(
-                classifierWeights: classifier,
-                vocabSize: vocabSize,
-                layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
-            )
-        }
-    }
-
-    private static func makeANERMSNormClassifierHead(
+    /// Compiles exactly the output head the requested backend needs; the
+    /// returned selection is presence-typed, so consumers never face a
+    /// backend whose head failed to exist.
+    private static func makeOutputHead(
         outputHeadBackend: GenerationOutputHeadBackend,
         vocabSize: Int,
         sharedClassifier: Bool,
@@ -3164,25 +2973,64 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
         embedding: borrowing TensorBuffer,
         classifier: borrowing TensorBuffer,
         laneSpatial: Int
-    ) throws(GenerationError) -> ANEGenerationRMSNormClassifierHead? {
+    ) throws(GenerationError) -> GenerationOutputHeadSelection {
         switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .aneClassifier, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
+        case .cpu, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+            return .cpuSgemm(outputHeadBackend)
+        case .aneClassifier:
+            if sharedClassifier {
+                return .aneClassifier(try ANEGenerationClassifierHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize,
+                    laneSpatial: laneSpatial
+                ))
+            }
+            return .aneClassifier(try ANEGenerationClassifierHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize,
+                laneSpatial: laneSpatial
+            ))
         case .aneRMSNormClassifier:
             if sharedClassifier {
-                return try ANEGenerationRMSNormClassifierHead(
+                return .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                     rmsFinal: rmsFinal,
                     classifierWeights: embedding,
                     vocabSize: vocabSize,
                     laneSpatial: laneSpatial
-                )
+                ))
             }
-            return try ANEGenerationRMSNormClassifierHead(
+            return .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                 rmsFinal: rmsFinal,
                 classifierWeights: classifier,
                 vocabSize: vocabSize,
                 laneSpatial: laneSpatial
-            )
+            ))
+        case .cpuExactStaged:
+            if sharedClassifier {
+                return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize,
+                    layoutStrategy: .contiguous(shardSize: 1024)
+                ))
+            }
+            return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize,
+                layoutStrategy: .contiguous(shardSize: 1024)
+            ))
+        case .cpuExactClustered:
+            if sharedClassifier {
+                return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize,
+                    layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
+                ))
+            }
+            return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize,
+                layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
+            ))
         }
     }
 
@@ -3390,8 +3238,10 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
         }
 
         stepLogits.zero()
-        switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+        switch outputHead {
+        case .cpuSgemm, .stagedCPU:
+            // Full-logits projection always runs the FP32 classifier, even for
+            // staged heads: they only accelerate argmax selection.
             stepLogits.withUnsafeMutablePointer { logitsPtr in
                 classifierPointer { clsPtr in
                     stepNorm.withUnsafePointer { normPtr in
@@ -3414,19 +3264,13 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
                     }
                 }
             }
-        case .aneClassifier:
-            guard let aneClassifierHead else {
-                throw .runtimeFailure("ANE classifier backend requested without compiled head")
-            }
-            try aneClassifierHead.project(normalizedInput: stepNorm, logits: stepLogits)
-        case .aneRMSNormClassifier:
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("ANE fused output-head backend requested without compiled head")
-            }
+        case .aneClassifier(let head):
+            try head.project(normalizedInput: stepNorm, logits: stepLogits)
+        case .aneRMSNormClassifier(let head):
             if currentActivationIsA {
-                try aneRMSNormClassifierHead.project(rawInput: activationA, logits: stepLogits)
+                try head.project(rawInput: activationA, logits: stepLogits)
             } else {
-                try aneRMSNormClassifierHead.project(rawInput: activationB, logits: stepLogits)
+                try head.project(rawInput: activationB, logits: stepLogits)
             }
         }
 
@@ -3473,65 +3317,20 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
         }
 
         let token: TokenID
-        switch outputHeadBackend {
-        case .cpu:
-            stepLogits.zero()
-            stepLogits.withUnsafeMutablePointer { logitsPtr in
-                classifierPointer { clsPtr in
-                    stepNorm.withUnsafePointer { normPtr in
-                        BLAS.sgemm(
-                            CblasRowMajor,
-                            CblasNoTrans,
-                            CblasNoTrans,
-                            m: Int32(vocabSize),
-                            n: 1,
-                            k: Int32(ModelConfig.dim),
-                            alpha: 1.0,
-                            a: clsPtr,
-                            lda: Int32(ModelConfig.dim),
-                            b: normPtr,
-                            ldb: 1,
-                            beta: 0.0,
-                            c: logitsPtr,
-                            ldc: 1
-                        )
-                    }
-                }
-            }
-            token = try selectToken(from: stepLogits, strategy: strategy)
-        case .cpuExactStaged:
-            guard let cpuExactStagedHead else {
-                throw .runtimeFailure("staged exact CPU output head requested without staged head")
-            }
-            token = try cpuExactStagedHead.selectArgmax(normalizedInput: stepNorm)
-        case .cpuExactClustered:
-            guard let cpuExactStagedHead else {
-                throw .runtimeFailure("clustered exact CPU output head requested without staged head")
-            }
-            token = try cpuExactStagedHead.selectArgmax(normalizedInput: stepNorm)
-        case .aneClassifier:
-            guard let aneClassifierHead else {
-                throw .runtimeFailure("ANE classifier backend requested without compiled head")
-            }
-            token = try aneClassifierHead.selectArgmax(normalizedInput: stepNorm)
-        case .aneRMSNormClassifier:
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("ANE fused output-head backend requested without compiled head")
-            }
+        switch outputHead {
+        case .stagedCPU(let head):
+            token = try head.selectArgmax(normalizedInput: stepNorm)
+        case .aneClassifier(let head):
+            token = try head.selectArgmax(normalizedInput: stepNorm)
+        case .aneRMSNormClassifier(let head):
             if currentActivationIsA {
-                token = try aneRMSNormClassifierHead.selectArgmax(rawInput: activationA)
+                token = try head.selectArgmax(rawInput: activationA)
             } else {
-                token = try aneRMSNormClassifierHead.selectArgmax(rawInput: activationB)
+                token = try head.selectArgmax(rawInput: activationB)
             }
-        case .cpuThenANE:
-            // If deferred ANE head is ready, use it; otherwise fall through to CPU sgemm
-            if let readyHead = deferredANEHead?.readyHead() {
-                if currentActivationIsA {
-                    token = try readyHead.selectArgmax(rawInput: activationA)
-                } else {
-                    token = try readyHead.selectArgmax(rawInput: activationB)
-                }
-            } else {
+        case .cpuSgemm(let backend):
+            switch backend {
+            case .cpu:
                 stepLogits.zero()
                 stepLogits.withUnsafeMutablePointer { logitsPtr in
                     classifierPointer { clsPtr in
@@ -3556,44 +3355,82 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
                     }
                 }
                 token = try selectToken(from: stepLogits, strategy: strategy)
-            }
-        case .cpuPartitionedArgmax:
-            // Partitioned argmax with Cauchy-Schwarz block pruning (greedy only)
-            var skippedBlocks = 0
-            let tokenIndex = partitionedLogitsScratch.withUnsafeMutablePointer { scratchPtr in
-                classifierPointer { clsPtr in
-                    stepNorm.withUnsafePointer { normPtr in
-                        blockMaxNorms.withUnsafeBufferPointer { normsPtr in
-                            PartitionedArgmax.compute(
-                                classifier: clsPtr,
-                                input: normPtr,
-                                logitsScratch: scratchPtr,
-                                blockMaxNorms: normsPtr.baseAddress!,
-                                vocabSize: vocabSize,
-                                dim: ModelConfig.dim,
-                                blockSize: PartitionedArgmax.defaultBlockSize,
-                                skippedBlocks: &skippedBlocks
-                            )
+            case .cpuThenANE:
+                // If deferred ANE head is ready, use it; otherwise fall through to CPU sgemm
+                if let readyHead = deferredANEHead?.readyHead() {
+                    if currentActivationIsA {
+                        token = try readyHead.selectArgmax(rawInput: activationA)
+                    } else {
+                        token = try readyHead.selectArgmax(rawInput: activationB)
+                    }
+                } else {
+                    stepLogits.zero()
+                    stepLogits.withUnsafeMutablePointer { logitsPtr in
+                        classifierPointer { clsPtr in
+                            stepNorm.withUnsafePointer { normPtr in
+                                BLAS.sgemm(
+                                    CblasRowMajor,
+                                    CblasNoTrans,
+                                    CblasNoTrans,
+                                    m: Int32(vocabSize),
+                                    n: 1,
+                                    k: Int32(ModelConfig.dim),
+                                    alpha: 1.0,
+                                    a: clsPtr,
+                                    lda: Int32(ModelConfig.dim),
+                                    b: normPtr,
+                                    ldb: 1,
+                                    beta: 0.0,
+                                    c: logitsPtr,
+                                    ldc: 1
+                                )
+                            }
+                        }
+                    }
+                    token = try selectToken(from: stepLogits, strategy: strategy)
+                }
+            case .cpuPartitionedArgmax:
+                // Partitioned argmax with Cauchy-Schwarz block pruning (greedy only)
+                var skippedBlocks = 0
+                let tokenIndex = partitionedLogitsScratch.withUnsafeMutablePointer { scratchPtr in
+                    classifierPointer { clsPtr in
+                        stepNorm.withUnsafePointer { normPtr in
+                            blockMaxNorms.withUnsafeBufferPointer { normsPtr in
+                                PartitionedArgmax.compute(
+                                    classifier: clsPtr,
+                                    input: normPtr,
+                                    logitsScratch: scratchPtr,
+                                    blockMaxNorms: normsPtr.baseAddress!,
+                                    vocabSize: vocabSize,
+                                    dim: ModelConfig.dim,
+                                    blockSize: PartitionedArgmax.defaultBlockSize,
+                                    skippedBlocks: &skippedBlocks
+                                )
+                            }
                         }
                     }
                 }
-            }
-            token = TokenID(tokenIndex)
-        case .cpuFP16Tiled:
-            guard classifierFP16.count > 0 else {
-                throw .runtimeFailure("FP16 tiled classifier backend requested without FP16 weights")
-            }
-            let tokenIndex = classifierFP16.withUnsafePointer { fp16Ptr in
-                stepNorm.withUnsafePointer { normPtr in
-                    FP16TiledClassifier.tiledMatvecArgmax(
-                        weights: fp16Ptr,
-                        input: normPtr,
-                        vocabSize: vocabSize,
-                        dim: ModelConfig.dim
-                    )
+                token = TokenID(tokenIndex)
+            case .cpuFP16Tiled:
+                guard classifierFP16.count > 0 else {
+                    throw .runtimeFailure("FP16 tiled classifier backend requested without FP16 weights")
                 }
+                let tokenIndex = classifierFP16.withUnsafePointer { fp16Ptr in
+                    stepNorm.withUnsafePointer { normPtr in
+                        FP16TiledClassifier.tiledMatvecArgmax(
+                            weights: fp16Ptr,
+                            input: normPtr,
+                            vocabSize: vocabSize,
+                            dim: ModelConfig.dim
+                        )
+                    }
+                }
+                token = TokenID(tokenIndex)
+            case .cpuExactStaged, .cpuExactClustered, .aneClassifier, .aneRMSNormClassifier:
+                // Unreachable: the selection payload pairs each of these backends
+                // with its compiled head, so they never land on a CPU-classifier route.
+                throw .runtimeFailure("output-head backend \(backend) requested without compiled head")
             }
-            token = TokenID(tokenIndex)
         }
 
         logitsLatencyMs += GenerationClock.milliseconds(start: logitsStart, end: GenerationClock.now())

--- a/Sources/RealModelInference/CompiledReadiness.swift
+++ b/Sources/RealModelInference/CompiledReadiness.swift
@@ -1,0 +1,91 @@
+import IOSurface
+
+/// Per-trunk compile readiness for the current engine session.
+///
+/// Replaces the former `compiled*` flag-and-conjunction family: a trunk is
+/// either `.notCompiled`, or `.compiled(runtime)` where the runtime was
+/// captured only after every program that trunk's decode loop requires became
+/// resident. Readiness checks switch over this enum exhaustively instead of
+/// re-deriving flag counts at each use site, and engine state transitions go
+/// through it — the ensure functions are the only writers.
+enum CompiledReadiness<Runtime> {
+    /// No programs are resident for this trunk yet.
+    case notCompiled
+    /// The trunk's validated runtime is resident and covers `runtime`'s bucket.
+    case compiled(Runtime)
+
+    /// The resident runtime, or `nil` when nothing is compiled.
+    var runtime: Runtime? {
+        switch self {
+        case .compiled(let runtime): runtime
+        case .notCompiled: nil
+        }
+    }
+}
+
+/// Programs required by the baseline (exact-CPU-routed ANE eval) decode loop.
+///
+/// Constructed only after every program the loop needs is resident, so a
+/// `.compiled` value proves the loop's former guard conjunction.
+struct BaselineCompiledRuntime {
+    /// Context bucket the programs were compiled for.
+    let bucket: Int
+    /// First-layer input surface the loop writes embeddings into.
+    let inputSurface: IOSurfaceRef
+}
+
+/// Programs required by the split-hybrid decode loop
+/// (ANE QKV → host attention → ANE FFN), shared by GPT-2 and llama sessions.
+struct SplitHybridCompiledRuntime {
+    /// Context bucket the programs were compiled for.
+    let bucket: Int
+    /// Output-head lane spatial; `> 0` once the head program is resident.
+    let headSpatial: Int
+
+    /// Captures the resident split-hybrid program facts, or `nil` unless every
+    /// program the loop requires is present. Llama sessions additionally
+    /// require one QK-norm weight entry per layer; pass `qKNormCount: nil` for
+    /// architectures without them.
+    init?(
+        bucket: Int,
+        layerCount: Int,
+        surfaceHandleCount: Int,
+        expectedLayerCount: Int,
+        headCount: Int,
+        qKNormCount: Int? = nil,
+        headSpatial: Int
+    ) {
+        guard layerCount == expectedLayerCount,
+              surfaceHandleCount == expectedLayerCount,
+              headCount == 1,
+              headSpatial > 0 else {
+            return nil
+        }
+        if let qKNormCount, qKNormCount != expectedLayerCount {
+            return nil
+        }
+        self.bucket = bucket
+        self.headSpatial = headSpatial
+    }
+}
+
+/// Programs required by the fused-hybrid decode loop (one ANE program per layer).
+struct FusedHybridCompiledRuntime {
+    /// Context bucket the programs were compiled for.
+    let bucket: Int
+
+    /// Captures the resident fused-hybrid program facts, or `nil` unless every
+    /// program the loop requires is present.
+    init?(
+        bucket: Int,
+        layerCount: Int,
+        surfaceHandleCount: Int,
+        expectedLayerCount: Int
+    ) {
+        guard layerCount == expectedLayerCount,
+              surfaceHandleCount == expectedLayerCount else {
+            return nil
+        }
+        self.bucket = bucket
+    }
+}

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -1523,11 +1523,19 @@ public struct RealModelInferenceEngine: ~Copyable {
         }
     }
 
-    private var compiledBucket: Int
+    /// Per-trunk compile readiness; the ensure functions below are the only writers.
+    private var baselineReadiness = CompiledReadiness<BaselineCompiledRuntime>.notCompiled
+    private var splitHybridReadiness = CompiledReadiness<SplitHybridCompiledRuntime>.notCompiled
+    private var fusedHybridReadiness = CompiledReadiness<FusedHybridCompiledRuntime>.notCompiled
+    /// Bucket of the last fully resident split-hybrid layer-program set.
+    ///
+    /// Incremental-compile watermark consulted only by ``ensureHybridCompiled``
+    /// (so a mid-compile failure never recompiles finished layers) and by the
+    /// dispatch max-sequence defaults; loop readiness itself is carried by
+    /// ``splitHybridReadiness``.
+    private var splitHybridLayerBucket = 0
     private var compiledLayers: LayerStorage<CompiledLayer>
-    private var firstLayerInputSurface: IOSurfaceRef?
     private var compiledHead: LayerStorage<CompiledHead>
-    private var compiledHybridBucket: Int
     private var compiledHybridLayers: LayerStorage<HybridDecodeKernelSet>
     private var compiledHybridSurfaceHandles: [HybridDecodeSurfaceHandles]
     private var compiledHybridLlamaQKNormWeights: [LlamaQKNormWeights?]
@@ -1536,7 +1544,6 @@ public struct RealModelInferenceEngine: ~Copyable {
     private var compiledHybridGreedyNorm: LayerStorage<CompiledHead>
     private var compiledHybridGreedyClassifier: LayerStorage<CompiledClassifier>
     private var compiledHybridGreedySpatial: Int
-    private var compiledFusedHybridBucket: Int
     private var compiledFusedHybridLayers: LayerStorage<FusedHybridDecodeLayerKernelSet>
     private var compiledFusedHybridSurfaceHandles: [FusedHybridDecodeSurfaceHandles]
     private var hybridMetalAttention: MetalAttentionKernel?
@@ -1576,11 +1583,8 @@ public struct RealModelInferenceEngine: ~Copyable {
         self.weightDirURL = weightDirURL
         self.tokenizer = tokenizer
         self.assets = assets
-        self.compiledBucket = 0
         self.compiledLayers = Self.emptyStorage(CompiledLayer.self)
-        self.firstLayerInputSurface = nil
         self.compiledHead = Self.emptyStorage(CompiledHead.self)
-        self.compiledHybridBucket = 0
         self.compiledHybridLayers = Self.emptyStorage(HybridDecodeKernelSet.self)
         self.compiledHybridSurfaceHandles = []
         self.compiledHybridLlamaQKNormWeights = []
@@ -1589,7 +1593,6 @@ public struct RealModelInferenceEngine: ~Copyable {
         self.compiledHybridGreedyNorm = Self.emptyStorage(CompiledHead.self)
         self.compiledHybridGreedyClassifier = Self.emptyStorage(CompiledClassifier.self)
         self.compiledHybridGreedySpatial = 0
-        self.compiledFusedHybridBucket = 0
         self.compiledFusedHybridLayers = Self.emptyStorage(FusedHybridDecodeLayerKernelSet.self)
         self.compiledFusedHybridSurfaceHandles = []
         self.hybridMetalAttention = nil
@@ -1709,7 +1712,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         }
         if trunk == .splitHybrid {
             let compileStart = DispatchTime.now().uptimeNanoseconds
-            let compileDidRun = try ensureHybridCompiledLlama(bucket: bucket)
+            let compileDidRun = try ensureHybridCompiled(bucket: bucket)
             guard let metalAttention = hybridMetalAttention else {
                 throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention unavailable for \(sessionKind)")
             }
@@ -1759,7 +1762,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 temperature: request.temperature,
                 topP: request.topP,
                 compileTimeMs: sessionCompileTimeMs,
-                maxSeq: request.maxSeq ?? max(request.bucket, compiledFusedHybridBucket),
+                maxSeq: request.maxSeq ?? max(request.bucket, fusedHybridReadiness.runtime?.bucket ?? request.bucket),
                 onStep: request.onStep,
                 isCancelled: request.isCancelled
             )
@@ -1790,7 +1793,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 temperature: request.temperature,
                 topP: request.topP,
                 compileTimeMs: sessionCompileTimeMs,
-                maxSeq: request.maxSeq ?? max(request.bucket, compiledHybridBucket),
+                maxSeq: request.maxSeq ?? max(request.bucket, splitHybridLayerBucket),
                 metalAttention: metalAttention,
                 onStep: request.onStep,
                 isCancelled: request.isCancelled
@@ -1922,21 +1925,22 @@ public struct RealModelInferenceEngine: ~Copyable {
         do {
             let hybridDidRun = try ensureHybridCompiled(bucket: bucket)
             compileDidRun = compileDidRun || hybridDidRun
-            useHybridFastPath =
-                compiledHybridLayers.count == config.nLayer &&
-                compiledHybridSurfaceHandles.count == config.nLayer &&
-                compiledHybridHead.count == 1 &&
-                hybridMetalAttention != nil
-            if !useHybridFastPath, !plan.allowsHybridFallback {
-                throw RealModelInferenceError.hybridFallbackDisabled(
-                    stage: "hybrid decode compile",
-                    reason: """
-                        hybrid decode state is incomplete: layers=\(compiledHybridLayers.count)/\(config.nLayer) \
-                        surfaces=\(compiledHybridSurfaceHandles.count)/\(config.nLayer) \
-                        head=\(compiledHybridHead.count)/1 \
-                        metalAttention=\(hybridMetalAttention != nil)
-                        """
-                )
+            switch splitHybridReadiness {
+            case .compiled:
+                useHybridFastPath = true
+            case .notCompiled:
+                useHybridFastPath = false
+                guard plan.allowsHybridFallback else {
+                    throw RealModelInferenceError.hybridFallbackDisabled(
+                        stage: "hybrid decode compile",
+                        reason: """
+                            hybrid decode state is incomplete: layers=\(compiledHybridLayers.count)/\(config.nLayer) \
+                            surfaces=\(compiledHybridSurfaceHandles.count)/\(config.nLayer) \
+                            head=\(compiledHybridHead.count)/1 \
+                            metalAttention=\(hybridMetalAttention != nil)
+                            """
+                    )
+                }
             }
         } catch let error as RealModelInferenceError {
             // A disabled-fallback error is the answer, not something to recover from.
@@ -2029,9 +2033,14 @@ public struct RealModelInferenceEngine: ~Copyable {
         let compileEnd = DispatchTime.now().uptimeNanoseconds
         let compileTimeMs = compileDidRun ? Self.milliseconds(from: compileEnd - compileStart) : 0
 
-        guard let inputSurface = firstLayerInputSurface, compiledLayers.count == config.nLayer, compiledHead.count == 1 else {
+        let baseline: BaselineCompiledRuntime
+        switch baselineReadiness {
+        case .compiled(let runtime):
+            baseline = runtime
+        case .notCompiled:
             throw RealModelInferenceError.runtimeFailure("Compiled ANE surfaces are unavailable")
         }
+        let inputSurface = baseline.inputSurface
 
         let generationStart = DispatchTime.now().uptimeNanoseconds
         let tokenizer = self.tokenizer
@@ -2044,7 +2053,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             startNanos: generationStart
         )
         var rng = SystemRandomNumberGenerator()
-        let activeBucket = compiledBucket
+        let activeBucket = baseline.bucket
 
         for _ in 0..<effectiveMaxTokens {
             let sequenceLength = emission.allTokensCount
@@ -4817,8 +4826,11 @@ public struct RealModelInferenceEngine: ~Copyable {
     }
 
     private mutating func ensureCompiled(bucket: Int) throws -> Bool {
-        guard compiledBucket < bucket else {
+        switch baselineReadiness {
+        case .compiled(let runtime) where runtime.bucket >= bucket:
             return false
+        case .compiled, .notCompiled:
+            break
         }
 
         let newLayers = try Self.compileLayers(
@@ -4842,144 +4854,30 @@ public struct RealModelInferenceEngine: ~Copyable {
         }
         compiledLayers = newLayers
         compiledHead = newHead
-        firstLayerInputSurface = newInputSurface
-        compiledBucket = bucket
+        baselineReadiness = .compiled(BaselineCompiledRuntime(bucket: bucket, inputSurface: newInputSurface))
         return true
     }
 
+    /// Compiles split-hybrid decode programs when the resident set covers less context.
+    ///
+    /// One parameterized implementation serves both model families: the former
+    /// GPT-2/llama ensure twins differed only in surface-handle geometry,
+    /// output-head compilation, and error prefixes. Split-hybrid readiness
+    /// transitions to `.compiled` after the output-head section, before the
+    /// family-specific greedy-classifier section — a greedy-head compile failure
+    /// must not unready the trunk's decode programs, matching the former flag
+    /// semantics where such failures still served hybrid decode via CPU logits.
     private mutating func ensureHybridCompiled(bucket: Int) throws -> Bool {
         var didCompile = false
 
-        if compiledHybridBucket < bucket {
-            let newLayers = try Self.compileHybridLayers(
-                config: config,
-                weightDirURL: weightDirURL,
-                maxSeq: bucket
-            )
-            let newQKNormWeights = try Self.loadHybridLlamaQKNormWeights(
-                config: config,
-                weightDirURL: weightDirURL
-            )
-            var newSurfaceHandles: [HybridDecodeSurfaceHandles] = []
-            newSurfaceHandles.reserveCapacity(newLayers.count)
-            for layerIndex in 0..<newLayers.count {
-                do {
-                    newSurfaceHandles.append(
-                        try HybridDecodeSurfaceHandles(
-                            kernels: newLayers[layerIndex],
-                            logicalMaxSeq: bucket
-                        )
-                    )
-                } catch {
-                    throw RealModelInferenceError.runtimeFailure(
-                        "Hybrid decode surfaces unavailable for layer \(layerIndex): \(error)"
-                    )
-                }
-            }
-            if newLayers.count > 1,
-               Self.usesHybridLayerInputRebinding(
-                   architecture: config.architecture,
-                   environment: Self.processEnvironment
-               ) {
-                for layerIndex in 1..<newLayers.count {
-                    do {
-                        try newLayers[layerIndex].decodeQKVOnly.rebindInput(
-                            at: 0,
-                            to: newSurfaceHandles[layerIndex - 1].ffnOut
-                        )
-                    } catch {
-                        throw RealModelInferenceError.runtimeFailure(
-                            "Hybrid decode chaining unavailable for layer \(layerIndex): \(error)"
-                        )
-                    }
-                }
-            }
+        // Both flavors share every program up to the output head; only the
+        // surface-handle geometry and head compilation differ.
+        let isLlama = config.architecture == .llama
+        let surfaceDim = isLlama ? config.dModel : ModelConfig.dim
+        let surfaceQDim: Int? = isLlama ? config.attentionDim : nil
+        let surfaceKVDim: Int? = isLlama ? config.nKVHead * config.headDim : nil
 
-            compiledHybridLayers = newLayers
-            compiledHybridSurfaceHandles = newSurfaceHandles
-            compiledHybridLlamaQKNormWeights = newQKNormWeights
-            compiledHybridBucket = bucket
-            didCompile = true
-        }
-
-        if compiledHybridLlamaQKNormWeights.count != config.nLayer {
-            compiledHybridLlamaQKNormWeights = try Self.loadHybridLlamaQKNormWeights(
-                config: config,
-                weightDirURL: weightDirURL
-            )
-        }
-
-        if hybridMetalAttention == nil {
-            do {
-                hybridMetalAttention = try MetalAttentionKernel()
-            } catch {
-                throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention initialization failed: \(error)")
-            }
-            didCompile = true
-        }
-
-        let hybridHeadSpatial = Self.incrementalHeadSpatial(channels: config.dModel)
-        if compiledHybridHead.count != 1 || compiledHybridHeadSpatial != hybridHeadSpatial {
-            compiledHybridHead = try LayerStorage<CompiledHead>(count: 1, throwingInitializer: { _ in
-                try Self.compileHead(
-                    config: config,
-                    weightDirURL: weightDirURL,
-                    assets: gpt2Assets,
-                    spatial: hybridHeadSpatial
-                )
-            })
-            compiledHybridHeadSpatial = hybridHeadSpatial
-            try Self.zeroSurface(compiledHybridHead[0].inputSurface)
-            didCompile = true
-        }
-
-        if classifierStrategy.usesANEClassifier {
-            if compiledHybridGreedyNorm.count != 1 ||
-                compiledHybridGreedyClassifier.count != 1 ||
-                compiledHybridGreedySpatial != hybridHeadSpatial {
-                compiledHybridGreedyNorm = try LayerStorage<CompiledHead>(count: 1, throwingInitializer: { _ in
-                    try Self.compileHead(
-                        config: config,
-                        weightDirURL: weightDirURL,
-                        assets: gpt2Assets,
-                        spatial: hybridHeadSpatial,
-                        inputDType: .fp16,
-                        outputDType: .fp16
-                    )
-                })
-                compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
-                    try Self.compileClassifier(
-                        config: config,
-                        assets: gpt2Assets,
-                        spatial: hybridHeadSpatial
-                    )
-                })
-                compiledHybridGreedySpatial = hybridHeadSpatial
-                try compiledHybridGreedyClassifier[0].kernel.rebindInput(
-                    at: 0,
-                    to: compiledHybridGreedyNorm[0].outputSurface
-                )
-                didCompile = true
-            }
-
-            if compiledHybridGreedyNorm.count == 1,
-               compiledHybridGreedyClassifier.count == 1,
-               let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
-                try compiledHybridGreedyNorm[0].kernel.rebindInput(at: 0, to: finalSurface)
-                try compiledHybridGreedyClassifier[0].kernel.rebindInput(
-                    at: 0,
-                    to: compiledHybridGreedyNorm[0].outputSurface
-                )
-            }
-        }
-
-        return didCompile
-    }
-
-    private mutating func ensureHybridCompiledLlama(bucket: Int) throws -> Bool {
-        var didCompile = false
-
-        if compiledHybridBucket < bucket {
+        if splitHybridLayerBucket < bucket {
             let newLayers = try Self.compileHybridLayers(
                 config: config,
                 weightDirURL: weightDirURL,
@@ -4997,14 +4895,14 @@ public struct RealModelInferenceEngine: ~Copyable {
                         try HybridDecodeSurfaceHandles(
                             kernels: newLayers[layerIndex],
                             logicalMaxSeq: bucket,
-                            dim: config.dModel,
-                            qDim: config.attentionDim,
-                            kvDim: config.nKVHead * config.headDim
+                            dim: surfaceDim,
+                            qDim: surfaceQDim,
+                            kvDim: surfaceKVDim
                         )
                     )
                 } catch {
                     throw RealModelInferenceError.runtimeFailure(
-                        "Llama hybrid decode surfaces unavailable for layer \(layerIndex): \(error)"
+                        "\(isLlama ? "Llama hybrid" : "Hybrid") decode surfaces unavailable for layer \(layerIndex): \(error)"
                     )
                 }
             }
@@ -5021,7 +4919,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                         )
                     } catch {
                         throw RealModelInferenceError.runtimeFailure(
-                            "Llama hybrid decode chaining unavailable for layer \(layerIndex): \(error)"
+                            "\(isLlama ? "Llama hybrid" : "Hybrid") decode chaining unavailable for layer \(layerIndex): \(error)"
                         )
                     }
                 }
@@ -5030,7 +4928,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             compiledHybridLayers = newLayers
             compiledHybridSurfaceHandles = newSurfaceHandles
             compiledHybridLlamaQKNormWeights = newQKNormWeights
-            compiledHybridBucket = bucket
+            splitHybridLayerBucket = bucket
             didCompile = true
         }
 
@@ -5045,21 +4943,28 @@ public struct RealModelInferenceEngine: ~Copyable {
             do {
                 hybridMetalAttention = try MetalAttentionKernel()
             } catch {
-                throw RealModelInferenceError.runtimeFailure("Llama hybrid Metal attention initialization failed: \(error)")
+                throw RealModelInferenceError.runtimeFailure(
+                    "\(isLlama ? "Llama hybrid" : "Hybrid") Metal attention initialization failed: \(error)"
+                )
             }
             didCompile = true
         }
 
         let hybridHeadSpatial = Self.incrementalHeadSpatial(channels: config.dModel)
-        let greedyHeadMode = hybridGreedyHeadMode()
-
-        // Compile RMSNorm head (no beta) for llama
         if compiledHybridHead.count != 1 || compiledHybridHeadSpatial != hybridHeadSpatial {
             compiledHybridHead = try LayerStorage<CompiledHead>(count: 1, throwingInitializer: { _ in
-                try Self.compileLlamaHead(
+                if isLlama {
+                    return try Self.compileLlamaHead(
+                        config: config,
+                        weightDirURL: weightDirURL,
+                        assets: llamaAssets,
+                        spatial: hybridHeadSpatial
+                    )
+                }
+                return try Self.compileHead(
                     config: config,
                     weightDirURL: weightDirURL,
-                    assets: llamaAssets,
+                    assets: gpt2Assets,
                     spatial: hybridHeadSpatial
                 )
             })
@@ -5068,78 +4973,131 @@ public struct RealModelInferenceEngine: ~Copyable {
             didCompile = true
         }
 
+        // Readiness transition: every program the split-hybrid decode loop
+        // requires is now resident, independent of the greedy head below.
+        if let runtime = SplitHybridCompiledRuntime(
+            bucket: max(bucket, splitHybridLayerBucket),
+            layerCount: compiledHybridLayers.count,
+            surfaceHandleCount: compiledHybridSurfaceHandles.count,
+            expectedLayerCount: config.nLayer,
+            headCount: compiledHybridHead.count,
+            qKNormCount: isLlama ? compiledHybridLlamaQKNormWeights.count : nil,
+            headSpatial: compiledHybridHeadSpatial
+        ) {
+            splitHybridReadiness = .compiled(runtime)
+        } else {
+            splitHybridReadiness = .notCompiled
+        }
+
         if classifierStrategy.usesANEClassifier {
-            switch greedyHeadMode {
-            case .classifierOnlyFactored:
-                if compiledHybridGreedyNorm.count != 0 {
-                    compiledHybridGreedyNorm = Self.emptyStorage(CompiledHead.self)
-                    didCompile = true
-                }
-                if compiledHybridGreedyClassifier.count != 1 {
-                    do {
+            if isLlama {
+                switch hybridGreedyHeadMode() {
+                case .classifierOnlyFactored:
+                    if compiledHybridGreedyNorm.count != 0 {
+                        compiledHybridGreedyNorm = Self.emptyStorage(CompiledHead.self)
+                        didCompile = true
+                    }
+                    if compiledHybridGreedyClassifier.count != 1 {
+                        do {
+                            compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
+                                try Self.compileLlamaFactoredClassifier(
+                                    config: config,
+                                    assets: llamaAssets,
+                                    spatial: hybridHeadSpatial
+                                )
+                            })
+                        } catch {
+                            fputs(
+                                "[RealModelInference] Llama factored classifier compile failed; falling back to dense ANE classifier: \(error)\n",
+                                stderr
+                            )
+                            compiledHybridGreedyClassifier = Self.emptyStorage(CompiledClassifier.self)
+                        }
+                        didCompile = true
+                    }
+                    if compiledHybridGreedyClassifier.count == 1,
+                       let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
+                        try compiledHybridGreedyClassifier[0].kernel.rebindInput(at: 0, to: finalSurface)
+                    }
+                case .classifierOnlyFused:
+                    if compiledHybridGreedyNorm.count != 0 {
+                        compiledHybridGreedyNorm = Self.emptyStorage(CompiledHead.self)
+                        didCompile = true
+                    }
+                    if compiledHybridGreedyClassifier.count != 1 {
                         compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
-                            try Self.compileLlamaFactoredClassifier(
+                            try Self.compileLlamaRMSNormClassifier(
                                 config: config,
                                 assets: llamaAssets,
                                 spatial: hybridHeadSpatial
                             )
                         })
-                    } catch {
-                        fputs(
-                            "[RealModelInference] Llama factored classifier compile failed; falling back to dense ANE classifier: \(error)\n",
-                            stderr
-                        )
-                        compiledHybridGreedyClassifier = Self.emptyStorage(CompiledClassifier.self)
+                        didCompile = true
                     }
-                    didCompile = true
-                }
-                if compiledHybridGreedyClassifier.count == 1,
-                   let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
-                    try compiledHybridGreedyClassifier[0].kernel.rebindInput(at: 0, to: finalSurface)
-                }
-            case .classifierOnlyFused:
-                if compiledHybridGreedyNorm.count != 0 {
-                    compiledHybridGreedyNorm = Self.emptyStorage(CompiledHead.self)
-                    didCompile = true
-                }
-                if compiledHybridGreedyClassifier.count != 1 {
-                    compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
-                        try Self.compileLlamaRMSNormClassifier(
-                            config: config,
-                            assets: llamaAssets,
-                            spatial: hybridHeadSpatial
+                    if compiledHybridGreedyClassifier.count == 1,
+                       let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
+                        try compiledHybridGreedyClassifier[0].kernel.rebindInput(at: 0, to: finalSurface)
+                    }
+                case .normThenClassifier:
+                    if compiledHybridGreedyNorm.count != 1 || compiledHybridGreedySpatial != hybridHeadSpatial {
+                        compiledHybridGreedyNorm = try LayerStorage<CompiledHead>(count: 1, throwingInitializer: { _ in
+                            try Self.compileLlamaHead(
+                                config: config,
+                                weightDirURL: weightDirURL,
+                                assets: llamaAssets,
+                                spatial: hybridHeadSpatial,
+                                inputDType: .fp16,
+                                outputDType: .fp16
+                            )
+                        })
+                        compiledHybridGreedySpatial = hybridHeadSpatial
+                        didCompile = true
+                    }
+
+                    if compiledHybridGreedyClassifier.count != 1 {
+                        compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
+                            try Self.compileLlamaClassifier(
+                                config: config,
+                                assets: llamaAssets,
+                                spatial: hybridHeadSpatial
+                            )
+                        })
+                        try compiledHybridGreedyClassifier[0].kernel.rebindInput(
+                            at: 0,
+                            to: compiledHybridGreedyNorm[0].outputSurface
                         )
-                    })
-                    didCompile = true
+                        didCompile = true
+                    }
+
+                    if compiledHybridGreedyClassifier.count == 1 {
+                        try compiledHybridGreedyClassifier[0].kernel.rebindInput(
+                            at: 0,
+                            to: compiledHybridGreedyNorm[0].outputSurface
+                        )
+                    }
                 }
-                if compiledHybridGreedyClassifier.count == 1,
-                   let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
-                    try compiledHybridGreedyClassifier[0].kernel.rebindInput(at: 0, to: finalSurface)
-                }
-            case .normThenClassifier:
-                if compiledHybridGreedyNorm.count != 1 || compiledHybridGreedySpatial != hybridHeadSpatial {
+            } else {
+                if compiledHybridGreedyNorm.count != 1 ||
+                    compiledHybridGreedyClassifier.count != 1 ||
+                    compiledHybridGreedySpatial != hybridHeadSpatial {
                     compiledHybridGreedyNorm = try LayerStorage<CompiledHead>(count: 1, throwingInitializer: { _ in
-                        try Self.compileLlamaHead(
+                        try Self.compileHead(
                             config: config,
                             weightDirURL: weightDirURL,
-                            assets: llamaAssets,
+                            assets: gpt2Assets,
                             spatial: hybridHeadSpatial,
                             inputDType: .fp16,
                             outputDType: .fp16
                         )
                     })
-                    compiledHybridGreedySpatial = hybridHeadSpatial
-                    didCompile = true
-                }
-
-                if compiledHybridGreedyClassifier.count != 1 {
                     compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
-                        try Self.compileLlamaClassifier(
+                        try Self.compileClassifier(
                             config: config,
-                            assets: llamaAssets,
+                            assets: gpt2Assets,
                             spatial: hybridHeadSpatial
                         )
                     })
+                    compiledHybridGreedySpatial = hybridHeadSpatial
                     try compiledHybridGreedyClassifier[0].kernel.rebindInput(
                         at: 0,
                         to: compiledHybridGreedyNorm[0].outputSurface
@@ -5147,7 +5105,10 @@ public struct RealModelInferenceEngine: ~Copyable {
                     didCompile = true
                 }
 
-                if compiledHybridGreedyClassifier.count == 1 {
+                if compiledHybridGreedyNorm.count == 1,
+                   compiledHybridGreedyClassifier.count == 1,
+                   let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
+                    try compiledHybridGreedyNorm[0].kernel.rebindInput(at: 0, to: finalSurface)
                     try compiledHybridGreedyClassifier[0].kernel.rebindInput(
                         at: 0,
                         to: compiledHybridGreedyNorm[0].outputSurface
@@ -5156,7 +5117,8 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        if compiledHybridGreedyNorm.count == 1,
+        if isLlama,
+           compiledHybridGreedyNorm.count == 1,
            let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
             try compiledHybridGreedyNorm[0].kernel.rebindInput(at: 0, to: finalSurface)
         }
@@ -5185,10 +5147,10 @@ public struct RealModelInferenceEngine: ~Copyable {
         onStep: ((GenerationStep) -> Void)?,
         isCancelled: (() -> Bool)? = nil
     ) throws -> GenerationResult {
-        guard compiledHybridLayers.count == config.nLayer,
-              compiledHybridSurfaceHandles.count == config.nLayer,
-              compiledHybridHead.count == 1,
-              compiledHybridHeadSpatial > 0 else {
+        switch splitHybridReadiness {
+        case .compiled:
+            break
+        case .notCompiled:
             throw RealModelInferenceError.runtimeFailure("Hybrid decode state is unavailable")
         }
 
@@ -5894,10 +5856,11 @@ public struct RealModelInferenceEngine: ~Copyable {
     }
 
     private mutating func ensureFusedHybridCompiled(bucket: Int) throws -> Bool {
-        if compiledFusedHybridBucket >= bucket,
-           compiledFusedHybridLayers.count == config.nLayer,
-           compiledFusedHybridSurfaceHandles.count == config.nLayer {
+        switch fusedHybridReadiness {
+        case .compiled(let runtime) where runtime.bucket >= bucket:
             return false
+        case .compiled, .notCompiled:
+            break
         }
 
         let newLayers: LayerStorage<FusedHybridDecodeLayerKernelSet>
@@ -5930,7 +5893,16 @@ public struct RealModelInferenceEngine: ~Copyable {
 
         compiledFusedHybridLayers = newLayers
         compiledFusedHybridSurfaceHandles = newSurfaceHandles
-        compiledFusedHybridBucket = bucket
+        if let runtime = FusedHybridCompiledRuntime(
+            bucket: bucket,
+            layerCount: compiledFusedHybridLayers.count,
+            surfaceHandleCount: compiledFusedHybridSurfaceHandles.count,
+            expectedLayerCount: config.nLayer
+        ) {
+            fusedHybridReadiness = .compiled(runtime)
+        } else {
+            fusedHybridReadiness = .notCompiled
+        }
         return true
     }
 
@@ -5980,8 +5952,10 @@ public struct RealModelInferenceEngine: ~Copyable {
         onStep: ((GenerationStep) -> Void)?,
         isCancelled: (() -> Bool)? = nil
     ) throws -> GenerationResult {
-        guard compiledFusedHybridLayers.count == config.nLayer,
-              compiledFusedHybridSurfaceHandles.count == config.nLayer else {
+        switch fusedHybridReadiness {
+        case .compiled:
+            break
+        case .notCompiled:
             throw Self.fusedHybridFallbackError(
                 reason: """
                     fused N=1 state is incomplete: \
@@ -6122,11 +6096,10 @@ public struct RealModelInferenceEngine: ~Copyable {
         onStep: ((GenerationStep) -> Void)?,
         isCancelled: (() -> Bool)? = nil
     ) throws -> GenerationResult {
-        guard compiledHybridLayers.count == config.nLayer,
-              compiledHybridSurfaceHandles.count == config.nLayer,
-              compiledHybridLlamaQKNormWeights.count == config.nLayer,
-              compiledHybridHead.count == 1,
-              compiledHybridHeadSpatial > 0 else {
+        switch splitHybridReadiness {
+        case .compiled:
+            break
+        case .notCompiled:
             throw RealModelInferenceError.runtimeFailure(
                 "Llama hybrid decode state is unavailable: layers=\(compiledHybridLayers.count)/\(config.nLayer) surfaces=\(compiledHybridSurfaceHandles.count)/\(config.nLayer) qkNorms=\(compiledHybridLlamaQKNormWeights.count)/\(config.nLayer) head=\(compiledHybridHead.count) headSpatial=\(compiledHybridHeadSpatial)"
             )

--- a/Tests/RealModelInferenceTests/CompiledReadinessTests.swift
+++ b/Tests/RealModelInferenceTests/CompiledReadinessTests.swift
@@ -1,0 +1,130 @@
+import Testing
+import IOSurface
+import ANETypes
+@testable import Espresso
+@testable import RealModelInference
+
+private func makeTestSurface() -> IOSurfaceRef {
+    let surface = IOSurfaceCreate([
+        kIOSurfaceWidth: 1,
+        kIOSurfaceHeight: 1,
+        kIOSurfaceBytesPerElement: 4,
+    ] as CFDictionary)!
+    return surface
+}
+
+@Suite struct CompiledReadinessTests {
+    // MARK: CompiledReadiness transitions
+
+    @Test func readinessTransitionsBetweenNotCompiledAndCompiled() {
+        var readiness = CompiledReadiness<BaselineCompiledRuntime>.notCompiled
+        #expect(readiness.runtime == nil)
+
+        readiness = .compiled(BaselineCompiledRuntime(bucket: 256, inputSurface: makeTestSurface()))
+        switch readiness {
+        case .compiled(let runtime):
+            #expect(runtime.bucket == 256)
+        case .notCompiled:
+            Issue.record("readiness should be compiled after the transition")
+        }
+    }
+
+    @Test func runtimeAccessorExposesOnlyTheResidentRuntime() {
+        let notCompiled = CompiledReadiness<FusedHybridCompiledRuntime>.notCompiled
+        #expect(notCompiled.runtime == nil)
+
+        guard let runtime = FusedHybridCompiledRuntime(
+            bucket: 512,
+            layerCount: 4,
+            surfaceHandleCount: 4,
+            expectedLayerCount: 4
+        ) else {
+            Issue.record("a complete fused program set must validate")
+            return
+        }
+        let resident = CompiledReadiness<FusedHybridCompiledRuntime>.compiled(runtime)
+        #expect(resident.runtime?.bucket == 512)
+    }
+
+    // MARK: SplitHybridCompiledRuntime validation
+
+    @Test func splitHybridRuntimeRejectsIncompleteProgramSets() {
+        // Missing layers
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 3, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 1, headSpatial: 32
+        ) == nil)
+        // Missing surfaces
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 3,
+            expectedLayerCount: 4, headCount: 1, headSpatial: 32
+        ) == nil)
+        // Missing head
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 0, headSpatial: 32
+        ) == nil)
+        // Degenerate head spatial
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 1, headSpatial: 0
+        ) == nil)
+    }
+
+    @Test func splitHybridRuntimeValidatesQKNormWeightsOnlyWhenRequested() {
+        // GPT-2 flavor: no QK-norm requirement.
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 1, qKNormCount: nil, headSpatial: 32
+        ) != nil)
+        // Llama flavor: one entry per layer is required.
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 1, qKNormCount: 4, headSpatial: 32
+        ) != nil)
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 1, qKNormCount: 3, headSpatial: 32
+        ) == nil)
+    }
+
+    // MARK: FusedHybridCompiledRuntime validation
+
+    @Test func fusedHybridRuntimeRequiresEveryLayerAndSurface() {
+        #expect(FusedHybridCompiledRuntime(
+            bucket: 128, layerCount: 4, surfaceHandleCount: 4, expectedLayerCount: 4
+        ) != nil)
+        #expect(FusedHybridCompiledRuntime(
+            bucket: 128, layerCount: 2, surfaceHandleCount: 4, expectedLayerCount: 4
+        ) == nil)
+        #expect(FusedHybridCompiledRuntime(
+            bucket: 128, layerCount: 4, surfaceHandleCount: 0, expectedLayerCount: 4
+        ) == nil)
+    }
+
+    // MARK: GenerationOutputHeadSelection backend derivation
+
+    @Test func cpuSgemmSelectionCarriesItsExactBackend() {
+        for backend in [GenerationOutputHeadBackend.cpu, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled] {
+            let selection = GenerationOutputHeadSelection.cpuSgemm(backend)
+            #expect(selection.backend == backend)
+        }
+    }
+
+    @Test func stagedCPUSelectionIsPresenceTypedAgainstTheStagedHead() throws {
+        let classifierWeights = TensorBuffer(count: ModelConfig.dim * 8, zeroed: true)
+        let stagedHead = try CPUStagedExactGenerationOutputHead(
+            classifierWeights: classifierWeights,
+            vocabSize: 8,
+            layoutStrategy: .contiguous(shardSize: 4)
+        )
+        let selection = GenerationOutputHeadSelection.stagedCPU(stagedHead)
+        switch selection {
+        case .stagedCPU:
+            // Presence-typed: no guard-throw needed to reach the head.
+            #expect(true)
+        case .cpuSgemm, .aneClassifier, .aneRMSNormClassifier:
+            Issue.record("staged selection must stay in the stagedCPU case")
+        }
+    }
+}


### PR DESCRIPTION
## Ticket T3 — Compiler-checked `CompiledReadiness` + merged ensure twins

Stacked on **#34** (T2) ← **#30** (T1) · final ticket of spec **`spec/spec-architecture-decode-serving-core.md`**.

### What changed
- New internal `Sources/RealModelInference/CompiledReadiness.swift`: per-trunk readiness enum (`CompiledReadiness<Runtime>` with validated payload runtimes) replacing the engine's ~16-flag conjunction family; all readiness checks are now exhaustive switches.
- The ~190-line `ensureHybridCompiled` / `ensureHybridCompiledLlama` twins merged into ONE parameterized function (surface geometry, head-compile call, error prefixes per architecture flavor; lazy semantics preserved incl. a layer-bucket watermark so mid-compile-failure retries never recompile finished ANE layers).
- `GenerationHarness`: output heads typed by presence — the eight "backend requested without compiled head"-style guard-throws collapse to exactly one unreachable-by-construction tripwire (base actually held 16 across three models; HEAD retains 1 pairing throw + 1 distinct weights-presence guard).
- New `CompiledReadinessTests.swift` (7 tests). Parity suites pass **unmodified**; unselected trunks still compile lazily only (ensure-call census byte-identical to base).

### Review evidence
- Fresh-context review pass 1: `swift-adversarial-pr-review` — CLEAN, zero fix commits required; every implementer claim field-verified against base d66443b semantics.
- Fresh-context final pass: `swift-adversarial-pr-review` — CLEAN; independent re-derivation of both ensure flavors, construction-site audit of the lone remaining throw, watermark consistency audit. One P3 follow-up recorded (compiler-invisible `.cpuExactStaged/Clustered` fall-through grouping at harness 1197 — behavior correct today, guarded by two runtime checks; left as future hardening).

### Validation
- `swift build` ✓ · policy/readiness filters 30 ✓ · full `RealModelInferenceTests` 149 ✓ · `EspressoTests` 198 executed, 79 hardware-gated self-skips, 0 failures
