### PR TITLE
Hybrid trunk kernel sets take compile options instead of reading env

### DIFF
--- a/Sources/ANERuntime/FusedHybridDecodeLayerKernelSet.swift
+++ b/Sources/ANERuntime/FusedHybridDecodeLayerKernelSet.swift
@@ -32,7 +32,8 @@ public struct FusedHybridDecodeLayerKernelSet: ~Copyable {
         nHeads: Int,
         nKVHeads: Int,
         headDim: Int,
-        donorHexIDs: DonorHexIDs? = nil
+        donorHexIDs: DonorHexIDs? = nil,
+        options: HybridDecodeKernelOptions? = nil
     ) throws(ANEError) {
         guard maxSeq > 0 else {
             throw .invalidArguments("fused hybrid decode maxSeq must be > 0")
@@ -40,7 +41,8 @@ public struct FusedHybridDecodeLayerKernelSet: ~Copyable {
         guard nHeads > 0, nKVHeads > 0, nHeads % nKVHeads == 0, headDim > 0 else {
             throw .invalidArguments("fused hybrid decode head geometry is invalid")
         }
-        let laneSpatial = HybridDecodeKernelSet.resolvedLaneSpatialForCurrentProcess()
+        let resolvedOptions = options ?? .resolve()
+        let laneSpatial = resolvedOptions.laneSpatial ?? DecodeKernelSet.defaultLaneSpatial
         let compiled = try Self.compile(
             weights: weights,
             maxSeq: maxSeq,
@@ -48,7 +50,8 @@ public struct FusedHybridDecodeLayerKernelSet: ~Copyable {
             nHeads: nHeads,
             nKVHeads: nKVHeads,
             headDim: headDim,
-            donorHexId: donorHexIDs?.fusedLayer
+            donorHexId: donorHexIDs?.fusedLayer,
+            disableDonorDelta: resolvedOptions.disableDonorDelta
         )
         let hexId = compiled.hexId
         self.fusedLayer = compiled
@@ -66,7 +69,8 @@ public struct FusedHybridDecodeLayerKernelSet: ~Copyable {
         nHeads: Int,
         nKVHeads: Int,
         headDim: Int,
-        donorHexId: String?
+        donorHexId: String?,
+        disableDonorDelta: Bool
     ) throws(ANEError) -> ANEKernel {
         let spec = makeSpec(
             weights: weights,
@@ -76,8 +80,7 @@ public struct FusedHybridDecodeLayerKernelSet: ~Copyable {
             nKVHeads: nKVHeads,
             headDim: headDim
         )
-        let donorDisabled = ProcessInfo.processInfo.environment["ESPRESSO_DISABLE_HYBRID_DONOR_DELTA"] == "1"
-        if !donorDisabled, let donorHexId, !donorHexId.isEmpty {
+        if !disableDonorDelta, let donorHexId, !donorHexId.isEmpty {
             do {
                 return try ANEKernel(
                     milText: spec.milText,

--- a/Sources/ANERuntime/HybridDecodeKernelSet.swift
+++ b/Sources/ANERuntime/HybridDecodeKernelSet.swift
@@ -25,6 +25,48 @@ public struct HybridOutputProjectionWeights: Sendable {
     }
 }
 
+/// Compile-time knobs for the hybrid trunk kernel sets, supplied by the
+/// caller instead of read from process state mid-compile.
+///
+/// Shared by both hybrid trunks: split (`HybridDecodeKernelSet`) and fused
+/// (`FusedHybridDecodeLayerKernelSet`). Fields a set doesn't use are ignored
+/// by that set. `resolve(environment:)` preserves the historical
+/// environment-driven defaults; embedded hosts pass values instead.
+public struct HybridDecodeKernelOptions: Sendable {
+    /// `ESPRESSO_DECODE_LANE_SPATIAL`, floored at the default lane spatial.
+    public var laneSpatial: Int?
+    /// `ESPRESSO_DISABLE_HYBRID_FUSED_POST_ATTENTION=1` (split trunk only).
+    public var disableFusedPostAttention: Bool
+    /// `ESPRESSO_ENABLE_HYBRID_FUSED_POST_ATTENTION=1` (GPT-2 opt-in, split trunk only).
+    public var enableFusedPostAttention: Bool
+    /// `ESPRESSO_DISABLE_HYBRID_DONOR_DELTA=1` (both trunks).
+    public var disableDonorDelta: Bool
+
+    public init(
+        laneSpatial: Int? = nil,
+        disableFusedPostAttention: Bool = false,
+        enableFusedPostAttention: Bool = false,
+        disableDonorDelta: Bool = false
+    ) {
+        self.laneSpatial = laneSpatial
+        self.disableFusedPostAttention = disableFusedPostAttention
+        self.enableFusedPostAttention = enableFusedPostAttention
+        self.disableDonorDelta = disableDonorDelta
+    }
+
+    public static func resolve(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> HybridDecodeKernelOptions {
+        let envSpatial = environment["ESPRESSO_DECODE_LANE_SPATIAL"].flatMap(Int.init)
+        return HybridDecodeKernelOptions(
+            laneSpatial: envSpatial.map { max(DecodeKernelSet.defaultLaneSpatial, $0) },
+            disableFusedPostAttention: environment["ESPRESSO_DISABLE_HYBRID_FUSED_POST_ATTENTION"] == "1",
+            enableFusedPostAttention: environment["ESPRESSO_ENABLE_HYBRID_FUSED_POST_ATTENTION"] == "1",
+            disableDonorDelta: environment["ESPRESSO_DISABLE_HYBRID_DONOR_DELTA"] == "1"
+        )
+    }
+}
+
 /// Owns the split decode path for ANE QKV-only + Metal attention + ANE FFN.
 public struct HybridDecodeKernelSet: ~Copyable {
     package struct DonorHexIDs {
@@ -124,29 +166,37 @@ public struct HybridDecodeKernelSet: ~Copyable {
         self.donorHexIDs = donorHexIDs
     }
 
-    public init(weights: borrowing LayerWeights, maxSeq: Int = ModelConfig.seqLen) throws(ANEError) {
-        try self.init(weights: weights, maxSeq: maxSeq, donorHexIDs: nil)
+    public init(
+        weights: borrowing LayerWeights,
+        maxSeq: Int = ModelConfig.seqLen,
+        options: HybridDecodeKernelOptions? = nil
+    ) throws(ANEError) {
+        try self.init(weights: weights, maxSeq: maxSeq, donorHexIDs: nil, options: options)
     }
 
     package init(
         weights: borrowing LayerWeights,
         maxSeq: Int = ModelConfig.seqLen,
-        donorHexIDs: DonorHexIDs? = nil
+        donorHexIDs: DonorHexIDs? = nil,
+        options: HybridDecodeKernelOptions? = nil
     ) throws(ANEError) {
         guard maxSeq > 0 else {
             throw .invalidArguments("hybrid decode maxSeq must be > 0")
         }
-        let laneSpatial = Self.resolvedLaneSpatialForCurrentProcess()
+        let resolvedOptions = options ?? .resolve()
+        let laneSpatial = resolvedOptions.laneSpatial ?? DecodeKernelSet.defaultLaneSpatial
         let compiledQKV = try Self.compileDecodeQKVOnly(
             weights: weights,
             laneSpatial: laneSpatial,
-            donorHexId: donorHexIDs?.decodeQKVOnly
+            donorHexId: donorHexIDs?.decodeQKVOnly,
+            options: resolvedOptions
         )
         let compiledPostAttention = try Self.compilePostAttention(
             weights: weights,
             laneSpatial: laneSpatial,
             donorProjectionHexId: donorHexIDs?.decodeProjection,
-            donorFFNHexId: donorHexIDs?.decodeFFN
+            donorFFNHexId: donorHexIDs?.decodeFFN,
+            options: resolvedOptions
         )
         let donorHexIDs = DonorHexIDs(
             decodeQKVOnly: compiledQKV.hexId,
@@ -174,9 +224,14 @@ public struct HybridDecodeKernelSet: ~Copyable {
         )
     }
 
-    internal static func compileSpecs(weights: borrowing LayerWeights, maxSeq: Int) -> [CompileSpec] {
+    internal static func compileSpecs(
+        weights: borrowing LayerWeights,
+        maxSeq: Int,
+        options: HybridDecodeKernelOptions? = nil
+    ) -> [CompileSpec] {
         precondition(maxSeq > 0)
-        let laneSpatial = resolvedLaneSpatialForCurrentProcess()
+        let resolvedOptions = options ?? .resolve()
+        let laneSpatial = resolvedOptions.laneSpatial ?? DecodeKernelSet.defaultLaneSpatial
         return [
             makeDecodeQKVOnlySpec(weights: weights, laneSpatial: laneSpatial),
             makeDecodeProjectionSpec(weights: weights, laneSpatial: laneSpatial),
@@ -187,10 +242,11 @@ public struct HybridDecodeKernelSet: ~Copyable {
     private static func compileDecodeQKVOnly(
         weights: borrowing LayerWeights,
         laneSpatial: Int,
-        donorHexId: String?
+        donorHexId: String?,
+        options: HybridDecodeKernelOptions
     ) throws(ANEError) -> ANEKernel {
         let spec = makeDecodeQKVOnlySpec(weights: weights, laneSpatial: laneSpatial)
-        return try compile(spec: spec, donorHexId: donorHexId)
+        return try compile(spec: spec, donorHexId: donorHexId, options: options)
     }
 
     private static func makeDecodeQKVOnlySpec(
@@ -260,19 +316,21 @@ public struct HybridDecodeKernelSet: ~Copyable {
     private static func compileDecodeFFN(
         weights: borrowing LayerWeights,
         laneSpatial: Int,
-        donorHexId: String?
+        donorHexId: String?,
+        options: HybridDecodeKernelOptions
     ) throws(ANEError) -> ANEKernel {
         let spec = makeDecodeFFNSpec(weights: weights, laneSpatial: laneSpatial)
-        return try compile(spec: spec, donorHexId: donorHexId)
+        return try compile(spec: spec, donorHexId: donorHexId, options: options)
     }
 
     private static func compileDecodeProjectionFFN(
         weights: borrowing LayerWeights,
         laneSpatial: Int,
-        donorHexId: String?
+        donorHexId: String?,
+        options: HybridDecodeKernelOptions
     ) throws(ANEError) -> ANEKernel {
         let spec = makeDecodeProjectionFFNSpec(weights: weights, laneSpatial: laneSpatial)
-        return try compile(spec: spec, donorHexId: donorHexId)
+        return try compile(spec: spec, donorHexId: donorHexId, options: options)
     }
 
     private static let fusedPostAttentionLock = NSLock()
@@ -285,11 +343,12 @@ public struct HybridDecodeKernelSet: ~Copyable {
         weights: borrowing LayerWeights,
         laneSpatial: Int,
         donorProjectionHexId: String?,
-        donorFFNHexId: String?
+        donorFFNHexId: String?,
+        options: HybridDecodeKernelOptions
     ) throws(ANEError) -> CompiledPostAttention {
-        // Fusion is enabled by default for rmsNormSwiGLU (LLaMA-family).
-        // Set ESPRESSO_DISABLE_HYBRID_FUSED_POST_ATTENTION=1 to force the split path.
-        let fusionDisabled = ProcessInfo.processInfo.environment["ESPRESSO_DISABLE_HYBRID_FUSED_POST_ATTENTION"] == "1"
+        // Fusion is enabled by default for rmsNormSwiGLU (LLaMA-family);
+        // disableFusedPostAttention forces the split path.
+        let fusionDisabled = options.disableFusedPostAttention
         let skipFused: Bool = {
             fusedPostAttentionLock.lock()
             defer { fusedPostAttentionLock.unlock() }
@@ -297,7 +356,7 @@ public struct HybridDecodeKernelSet: ~Copyable {
         }()
         let fusionEnabled = !fusionDisabled && !skipFused && (
             weights.architecture == .rmsNormSwiGLU ||
-            ProcessInfo.processInfo.environment["ESPRESSO_ENABLE_HYBRID_FUSED_POST_ATTENTION"] == "1"
+            options.enableFusedPostAttention
         )
         if fusionEnabled {
             do {
@@ -305,12 +364,14 @@ public struct HybridDecodeKernelSet: ~Copyable {
                     decodeProjection: try compileDecodeProjectionFFN(
                         weights: weights,
                         laneSpatial: laneSpatial,
-                        donorHexId: donorProjectionHexId
+                        donorHexId: donorProjectionHexId,
+                        options: options
                     ),
                     decodeFFN: try compileDecodeFFN(
                         weights: weights,
                         laneSpatial: laneSpatial,
-                        donorHexId: donorFFNHexId
+                        donorHexId: donorFFNHexId,
+                        options: options
                     ),
                     usesFusedPostAttention: true
                 )
@@ -331,12 +392,14 @@ public struct HybridDecodeKernelSet: ~Copyable {
             decodeProjection: try compileDecodeProjection(
                 weights: weights,
                 laneSpatial: laneSpatial,
-                donorHexId: donorProjectionHexId
+                donorHexId: donorProjectionHexId,
+                options: options
             ),
             decodeFFN: try compileDecodeFFN(
                 weights: weights,
                 laneSpatial: laneSpatial,
-                donorHexId: donorFFNHexId
+                donorHexId: donorFFNHexId,
+                options: options
             ),
             usesFusedPostAttention: false
         )
@@ -345,14 +408,19 @@ public struct HybridDecodeKernelSet: ~Copyable {
     private static func compileDecodeProjection(
         weights: borrowing LayerWeights,
         laneSpatial: Int,
-        donorHexId: String?
+        donorHexId: String?,
+        options: HybridDecodeKernelOptions
     ) throws(ANEError) -> ANEKernel {
         let spec = makeDecodeProjectionSpec(weights: weights, laneSpatial: laneSpatial)
-        return try compile(spec: spec, donorHexId: donorHexId)
+        return try compile(spec: spec, donorHexId: donorHexId, options: options)
     }
 
-    private static func compile(spec: CompileSpec, donorHexId: String?) throws(ANEError) -> ANEKernel {
-        let donorDisabled = ProcessInfo.processInfo.environment["ESPRESSO_DISABLE_HYBRID_DONOR_DELTA"] == "1"
+    private static func compile(
+        spec: CompileSpec,
+        donorHexId: String?,
+        options: HybridDecodeKernelOptions
+    ) throws(ANEError) -> ANEKernel {
+        let donorDisabled = options.disableDonorDelta
         let compileLabelPrefix = "hybrid.\(spec.kind.rawValue)"
         if !donorDisabled, let donorHexId, !donorHexId.isEmpty {
             do {

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -5753,7 +5753,8 @@ public struct RealModelInferenceEngine: ~Copyable {
             newLayers = try Self.compileFusedHybridLayers(
                 config: config,
                 weightDirURL: weightDirURL,
-                maxSeq: bucket
+                maxSeq: bucket,
+                environment: policies.environment
             )
         } catch let error as RealModelInferenceError {
             if case .hybridFallbackDisabled = error { throw error }
@@ -5785,7 +5786,8 @@ public struct RealModelInferenceEngine: ~Copyable {
     private static func compileFusedHybridLayers(
         config: MultiModelConfig,
         weightDirURL: URL,
-        maxSeq: Int
+        maxSeq: Int,
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> LayerStorage<FusedHybridDecodeLayerKernelSet> {
         guard config.nHead > 0, config.nKVHead > 0, config.headDim > 0,
               config.nHead % config.nKVHead == 0 else {
@@ -5811,7 +5813,8 @@ public struct RealModelInferenceEngine: ~Copyable {
                 nHeads: config.nHead,
                 nKVHeads: config.nKVHead,
                 headDim: config.headDim,
-                donorHexIDs: donor
+                donorHexIDs: donor,
+                options: HybridDecodeKernelOptions.resolve(environment: environment)
             )
             donor = compiled.donorHexIDs
             return compiled
@@ -6877,6 +6880,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> LayerStorage<HybridDecodeKernelSet> {
         let layerRange = sourceLayerRange ?? (0..<config.nLayer)
+        let kernelOptions = HybridDecodeKernelOptions.resolve(environment: environment)
         let useDonorDelta = supportsHybridDonorDelta(
             config: config,
             environment: environment
@@ -6893,7 +6897,8 @@ public struct RealModelInferenceEngine: ~Copyable {
                 let kernels = try HybridDecodeKernelSet(
                     weights: weights,
                     maxSeq: maxSeq,
-                    donorHexIDs: useDonorDelta ? donorHexIDs : nil
+                    donorHexIDs: useDonorDelta ? donorHexIDs : nil,
+                    options: kernelOptions
                 )
                 if useDonorDelta {
                     donorHexIDs = kernels.donorHexIDs

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,14 @@
 # Espresso — Current Plan
 
-Last updated: 2026-08-13 (productization ship)
+Last updated: 2026-08-22 (architecture deepening stack)
+
+## Architecture deepening PRs (2026-08-22, stacked)
+
+- [x] #31 `arch/artifact-loader`: one top-level weight loader (`TopLevelAssetLoader`), misnamed `loadTestingTopLevelAssets` deleted
+- [x] #32 `arch/hybrid-step-assembler`: split/fused-hybrid surface bindings moved into ANERuntime; `evalPostAttention()` replaces fusion branching at call sites
+- [x] #35 `arch/resolved-engine-policies`: `EnginePolicies` resolved once at `build(environment:)`; serving paths stop reading live process state; runner setenv channel deleted
+
+Follow-ups (not started): kernel-set compile options threaded from policies; DecodeRuntimeOptions statics; CLI env seeding for compile-cache policy.
 
 ## What Espresso is today
 


### PR DESCRIPTION
## What

The last live process reads on the serving path's compile orchestration move behind an options value:

1. **`HybridDecodeKernelOptions`** (new, public in ANERuntime): `laneSpatial`, `disableFusedPostAttention`, `enableFusedPostAttention`, `disableDonorDelta`. `resolve(environment:)` reproduces the historical env-driven defaults exactly; callers can pass values instead.

2. **Both hybrid trunk kernel sets accept `options:` at init** — split (`HybridDecodeKernelSet`) and fused (`FusedHybridDecodeLayerKernelSet`). All internal compile helpers (QKV, projection, FFN, fused projection+FFN, donor-delta gating) thread the value; zero `ProcessInfo` reads remain in these kernel sets' compile paths.

3. **The engine supplies options from its policies snapshot**: `compileHybridLayers` builds them from its environment parameter; `compileFusedHybridLayers` gains one too, fed by `ensureFusedHybridCompiled` from policies. Harness and benchmark callers omit `options` and keep today's env-default behavior.

`resolvedLaneSpatialForCurrentProcess()` stays for probe/test callers; kernel-set inits no longer consult it.

## Why

Completes candidate 1's promise for the kernel seam: after #35 resolved engine policies once at build, the compile orchestration still read live process state inside ANERuntime mid-compile — meaning a `setenv` racing a layer compile could flip fusion or donor-delta decisions between layers of the same model load. Now everything derives from the one dictionary handed to `build(environment:)`.

## Verification

- `swift build` green
- `swift test`: 540 executed, 0 failures (169 hardware-gated skips), identical to baseline
- Kernel-set spec tests (`HybridDecodeKernelSetTests.compileSpecs`) pass unchanged via the env-default path

Stacked on #35 (which is stacked on #32 ← #31). Full chain: #31 → #32 → #35 → this.
