### PR TITLE
Integrate decode-path stack (#30/#34/#36) over engine-policies stack

### DIFF
--- a/Sources/Espresso/DecodeForwardPass.swift
+++ b/Sources/Espresso/DecodeForwardPass.swift
@@ -1631,12 +1631,14 @@ public extension ForwardPass {
         decodeState: inout DecodeState,
         dim: Int = ModelConfig.dim,
         timings: inout StepTimingBreakdown,
-        profiler: DecodeKernelProfiler? = nil
+        profiler: DecodeKernelProfiler? = nil,
+        ffnOnlyEval: Bool? = nil
     ) throws(ANEError) {
         precondition(kernels.count > 0)
         precondition(surfaceHandles.count == kernels.count)
         precondition(dim > 0)
         precondition(xCur.count == dim)
+        let evalFFNOnly = ffnOnlyEval ?? (ProcessInfo.processInfo.environment["DECODE_EVAL_FFN_ONLY"] == "1")
         let maxSeq = decodeState.maxSeq
         for handles in surfaceHandles {
             precondition(handles.maxSeq == maxSeq)
@@ -1685,7 +1687,7 @@ public extension ForwardPass {
                 }
             }
 
-            if ProcessInfo.processInfo.environment["DECODE_EVAL_FFN_ONLY"] == "1" {
+            if evalFFNOnly {
                 t0 = RuntimeClock.now()
                 do {
                     try SurfaceIO.copyFP16(

--- a/Sources/Espresso/GenerationHarness.swift
+++ b/Sources/Espresso/GenerationHarness.swift
@@ -21,6 +21,36 @@ public enum RecurrentGenerationTrunkBackend: Sendable {
     case identityZeroTrunk
 }
 
+/// Presence-typed output-head selection: the compiled head itself carries which
+/// backend it serves, so requesting token selection against an uncompiled
+/// backend is unrepresentable instead of a runtime throw.
+///
+/// Replaces the former parallel `outputHeadBackend`-plus-three-optional-heads
+/// state whose mismatch produced "backend requested without compiled head"
+/// failures at every use site.
+enum GenerationOutputHeadSelection {
+    /// CPU-classifier backends (`cpu`, `cpuThenANE`, `cpuPartitionedArgmax`,
+    /// `cpuFP16Tiled`) that classify over the FP32 classifier weights; carries
+    /// the exact backend for deferred-head and tiled-argmax routing.
+    case cpuSgemm(GenerationOutputHeadBackend)
+    /// Staged or clustered exact-CPU head — identical post-construction.
+    case stagedCPU(CPUStagedExactGenerationOutputHead)
+    case aneClassifier(ANEGenerationClassifierHead)
+    case aneRMSNormClassifier(ANEGenerationRMSNormClassifierHead)
+
+    /// Backend this selection was constructed from. Staged and clustered
+    /// backends are indistinguishable after construction; both report as
+    /// `.cpuExactStaged`.
+    var backend: GenerationOutputHeadBackend {
+        switch self {
+        case .cpuSgemm(let backend): backend
+        case .stagedCPU: .cpuExactStaged
+        case .aneClassifier: .aneClassifier
+        case .aneRMSNormClassifier: .aneRMSNormClassifier
+        }
+    }
+}
+
 public struct GenerationPerformanceSnapshot: Sendable, Equatable {
     public let compileTimeMs: Double
     public let trunkLatencyMs: Double
@@ -892,13 +922,14 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
     private let currentProposalActivation: TensorBuffer
     private let stepRMSWorkspace: RMSNorm.Workspace
     private let futureRMSWorkspace: RMSNorm.Workspace
-    private let outputHeadBackend: GenerationOutputHeadBackend
-    private let futureOutputHeadBackend: GenerationOutputHeadBackend
+    /// Current-side output head, presence-typed against its backend.
+    private let outputHead: GenerationOutputHeadSelection
+    /// Future-proposer output head, presence-typed against its backend
+    /// (`.cpuSgemm(.cpu)` when this model has no future proposer).
+    private let futureOutputHead: GenerationOutputHeadSelection
+    private var outputHeadBackend: GenerationOutputHeadBackend { outputHead.backend }
+    private var futureOutputHeadBackend: GenerationOutputHeadBackend { futureOutputHead.backend }
     private let trunkBackend: RecurrentGenerationTrunkBackend
-    private let aneClassifierHead: ANEGenerationClassifierHead?
-    private let aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
-    private let futureANEClassifierHead: ANEGenerationClassifierHead?
-    private let futureANERMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
     private let sharedOutputHeadWeights: SharedReadOnlyOutputHeadWeights
     private var twoStepSessions: LayerStorage<RWKVStyleTwoStepRecurrentSession>
     private var fusedPairTwoStepSessions: LayerStorage<RWKVStyleFusedTwoLayerTwoStepSession>
@@ -1091,89 +1122,80 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
             hasFutureProposer = false
         }
 
-        let aneClassifierHead: ANEGenerationClassifierHead?
+        let outputHead: GenerationOutputHeadSelection
         switch outputHeadBackend {
         case .aneClassifier:
             do {
                 if sharedClassifier {
-                    aneClassifierHead = try ANEGenerationClassifierHead(
+                    outputHead = .aneClassifier(try ANEGenerationClassifierHead(
                         classifierWeights: embedding,
                         vocabSize: vocabSize,
                         laneSpatial: outputHeadLaneSpatial
-                    )
+                    ))
                 } else {
-                    aneClassifierHead = try ANEGenerationClassifierHead(
+                    outputHead = .aneClassifier(try ANEGenerationClassifierHead(
                         classifierWeights: classifier,
                         vocabSize: vocabSize,
                         laneSpatial: outputHeadLaneSpatial
-                    )
+                    ))
                 }
             } catch {
                 throw .runtimeFailure("two-step ANE classifier setup failed: \(error)")
             }
-        default:
-            aneClassifierHead = nil
-        }
-
-        let aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
-        switch outputHeadBackend {
         case .aneRMSNormClassifier:
             do {
                 if sharedClassifier {
-                    aneRMSNormClassifierHead = try ANEGenerationRMSNormClassifierHead(
+                    outputHead = .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                         rmsFinal: rmsFinal,
                         classifierWeights: embedding,
                         vocabSize: vocabSize,
                         laneSpatial: outputHeadLaneSpatial
-                    )
+                    ))
                 } else {
-                    aneRMSNormClassifierHead = try ANEGenerationRMSNormClassifierHead(
+                    outputHead = .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                         rmsFinal: rmsFinal,
                         classifierWeights: classifier,
                         vocabSize: vocabSize,
                         laneSpatial: outputHeadLaneSpatial
-                    )
+                    ))
                 }
             } catch {
                 throw .runtimeFailure("two-step ANE fused output-head setup failed: \(error)")
             }
-        default:
-            aneRMSNormClassifierHead = nil
+        case .cpuExactStaged, .cpuExactClustered:
+            // Also rejected up front before any session compilation; unreachable here.
+            throw .invalidArguments("two-step branch-state promotion model does not support staged CPU output heads")
+        case .cpu, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+            outputHead = .cpuSgemm(outputHeadBackend)
         }
 
-        let futureOutputHeadBackend: GenerationOutputHeadBackend = hasFutureProposer ? outputHeadBackend : .cpu
+        let futureOutputHeadBackend = hasFutureProposer ? outputHeadBackend : .cpu
 
-        let futureANEClassifierHead: ANEGenerationClassifierHead?
+        let futureOutputHead: GenerationOutputHeadSelection
         switch futureOutputHeadBackend {
         case .aneClassifier:
             do {
-                futureANEClassifierHead = try ANEGenerationClassifierHead(
+                futureOutputHead = .aneClassifier(try ANEGenerationClassifierHead(
                     classifierWeights: futureClassifier,
                     vocabSize: vocabSize,
                     laneSpatial: Self.futureProposerOutputHeadLaneSpatial
-                )
+                ))
             } catch {
                 throw .runtimeFailure("two-step ANE future proposer setup failed: \(error)")
             }
-        default:
-            futureANEClassifierHead = nil
-        }
-
-        let futureANERMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
-        switch futureOutputHeadBackend {
         case .aneRMSNormClassifier:
             do {
-                futureANERMSNormClassifierHead = try ANEGenerationRMSNormClassifierHead(
+                futureOutputHead = .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                     rmsFinal: futureRMS,
                     classifierWeights: futureClassifier,
                     vocabSize: vocabSize,
                     laneSpatial: Self.futureProposerOutputHeadLaneSpatial
-                )
+                ))
             } catch {
                 throw .runtimeFailure("two-step ANE future proposer setup failed: \(error)")
             }
-        default:
-            futureANERMSNormClassifierHead = nil
+        case .cpuExactStaged, .cpuExactClustered, .cpu, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+            futureOutputHead = .cpuSgemm(futureOutputHeadBackend)
         }
 
         self.vocabSize = vocabSize
@@ -1198,13 +1220,9 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
         self.currentProposalActivation = TensorBuffer(count: ModelConfig.dim, zeroed: true)
         self.stepRMSWorkspace = RMSNorm.Workspace(seqLen: 1)
         self.futureRMSWorkspace = RMSNorm.Workspace(seqLen: 1)
-        self.outputHeadBackend = outputHeadBackend
-        self.futureOutputHeadBackend = futureOutputHeadBackend
         self.trunkBackend = trunkBackend
-        self.aneClassifierHead = aneClassifierHead
-        self.aneRMSNormClassifierHead = aneRMSNormClassifierHead
-        self.futureANEClassifierHead = futureANEClassifierHead
-        self.futureANERMSNormClassifierHead = futureANERMSNormClassifierHead
+        self.outputHead = outputHead
+        self.futureOutputHead = futureOutputHead
         self.sharedOutputHeadWeights = sharedOutputHeadWeights
         self.twoStepSessions = twoStepSessions
         self.fusedPairTwoStepSessions = fusedPairTwoStepSessions
@@ -1364,15 +1382,13 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
             let exactNextToken = try Self.selectTokenFromActivation(
                 pair0ActivationA,
                 strategy: strategy,
-                outputHeadBackend: outputHeadBackend,
+                outputHead: outputHead,
                 rmsFinal: rmsFinal,
                 stepNorm: stepNorm,
                 stepLogits: stepLogits,
                 embedding: embedding,
                 classifier: classifier,
                 sharedClassifier: sharedClassifier,
-                aneClassifierHead: aneClassifierHead,
-                aneRMSNormClassifierHead: aneRMSNormClassifierHead,
                 vocabSize: vocabSize,
                 stepRMSWorkspace: stepRMSWorkspace
             )
@@ -1527,15 +1543,13 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
                 pair0ActivationA,
                 pair1ActivationA,
                 strategy: strategy,
-                outputHeadBackend: outputHeadBackend,
+                outputHead: outputHead,
                 rmsFinal: rmsFinal,
                 stepNorm: stepNorm,
                 stepLogits: stepLogits,
                 embedding: embedding,
                 classifier: classifier,
                 sharedClassifier: sharedClassifier,
-                aneClassifierHead: aneClassifierHead,
-                aneRMSNormClassifierHead: aneRMSNormClassifierHead,
                 vocabSize: vocabSize,
                 stepRMSWorkspace: stepRMSWorkspace
             )
@@ -1544,15 +1558,13 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
                 pair0ActivationB,
                 pair1ActivationB,
                 strategy: strategy,
-                outputHeadBackend: outputHeadBackend,
+                outputHead: outputHead,
                 rmsFinal: rmsFinal,
                 stepNorm: stepNorm,
                 stepLogits: stepLogits,
                 embedding: embedding,
                 classifier: classifier,
                 sharedClassifier: sharedClassifier,
-                aneClassifierHead: aneClassifierHead,
-                aneRMSNormClassifierHead: aneRMSNormClassifierHead,
                 vocabSize: vocabSize,
                 stepRMSWorkspace: stepRMSWorkspace
             )
@@ -1630,15 +1642,13 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
         return try Self.selectTokenFromActivation(
             currentProposalActivation,
             strategy: strategy,
-            outputHeadBackend: futureOutputHeadBackend,
+            outputHead: futureOutputHead,
             rmsFinal: futureRMS,
             stepNorm: futureNorm,
             stepLogits: futureLogits,
             embedding: embedding,
             classifier: futureClassifier,
             sharedClassifier: false,
-            aneClassifierHead: futureANEClassifierHead,
-            aneRMSNormClassifierHead: futureANERMSNormClassifierHead,
             vocabSize: vocabSize,
             stepRMSWorkspace: futureRMSWorkspace
         )
@@ -1689,21 +1699,20 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
 
     private static func selectTokenFromActivation(
         _ activation: borrowing TensorBuffer,
-        strategy: TokenSelectionStrategy
-        ,
-        outputHeadBackend: GenerationOutputHeadBackend,
+        strategy: TokenSelectionStrategy,
+        outputHead: GenerationOutputHeadSelection,
         rmsFinal: borrowing TensorBuffer,
         stepNorm: borrowing TensorBuffer,
         stepLogits: borrowing TensorBuffer,
         embedding: borrowing TensorBuffer,
         classifier: borrowing TensorBuffer,
         sharedClassifier: Bool,
-        aneClassifierHead: ANEGenerationClassifierHead?,
-        aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?,
         vocabSize: Int,
         stepRMSWorkspace: borrowing RMSNorm.Workspace
     ) throws(GenerationError) -> TokenID {
-        if outputHeadBackend != .aneRMSNormClassifier {
+        // The fused head applies RMSNorm internally over the raw activation;
+        // every other route classifies the normalized activation.
+        if outputHead.backend != .aneRMSNormClassifier {
             activation.withUnsafePointer { xPtr in
                 stepNorm.withUnsafeMutablePointer { normPtr in
                     rmsFinal.withUnsafePointer { rmsPtr in
@@ -1721,8 +1730,8 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
         }
 
         let token: TokenID
-        switch outputHeadBackend {
-        case .cpu:
+        switch outputHead {
+        case .cpuSgemm:
             // beta=0.0 means sgemm overwrites C entirely — no pre-zeroing needed
             stepLogits.withUnsafeMutablePointer { logitsPtr in
                 classifierPointer(
@@ -1751,47 +1760,15 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
                 }
             }
             token = try selectToken(from: stepLogits, strategy: strategy)
-        case .aneClassifier:
-            guard let aneClassifierHead else {
-                throw .runtimeFailure("two-step ANE classifier backend requested without compiled head")
-            }
-            token = try aneClassifierHead.selectArgmax(normalizedInput: stepNorm)
-        case .aneRMSNormClassifier:
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("two-step ANE fused output-head backend requested without compiled head")
-            }
-            token = try aneRMSNormClassifierHead.selectArgmax(rawInput: activation)
-        case .cpuExactStaged, .cpuExactClustered:
+        case .stagedCPU:
+            // The two-step initializer rejects staged CPU heads up front, so a
+            // staged selection cannot reach this model; keep the capability
+            // boundary explicit rather than guessing a route.
             throw .runtimeFailure("two-step branch-state promotion model does not support staged CPU output heads")
-        case .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            // Fall through to CPU sgemm path for now
-            stepLogits.withUnsafeMutablePointer { logitsPtr in
-                classifierPointer(
-                    sharedClassifier: sharedClassifier,
-                    embedding: embedding,
-                    classifier: classifier
-                ) { clsPtr in
-                    stepNorm.withUnsafePointer { normPtr in
-                        BLAS.sgemm(
-                            CblasRowMajor,
-                            CblasNoTrans,
-                            CblasNoTrans,
-                            m: Int32(vocabSize),
-                            n: 1,
-                            k: Int32(ModelConfig.dim),
-                            alpha: 1.0,
-                            a: clsPtr,
-                            lda: Int32(ModelConfig.dim),
-                            b: normPtr,
-                            ldb: 1,
-                            beta: 0.0,
-                            c: logitsPtr,
-                            ldc: 1
-                        )
-                    }
-                }
-            }
-            token = try selectToken(from: stepLogits, strategy: strategy)
+        case .aneClassifier(let head):
+            token = try head.selectArgmax(normalizedInput: stepNorm)
+        case .aneRMSNormClassifier(let head):
+            token = try head.selectArgmax(rawInput: activation)
         }
 
         return token
@@ -1801,56 +1778,50 @@ public struct ANEExactTwoTokenBranchStatePromotionModel: ~Copyable, ExactTwoToke
         _ activationA: borrowing TensorBuffer,
         _ activationB: borrowing TensorBuffer,
         strategy: TokenSelectionStrategy,
-        outputHeadBackend: GenerationOutputHeadBackend,
+        outputHead: GenerationOutputHeadSelection,
         rmsFinal: borrowing TensorBuffer,
         stepNorm: borrowing TensorBuffer,
         stepLogits: borrowing TensorBuffer,
         embedding: borrowing TensorBuffer,
         classifier: borrowing TensorBuffer,
         sharedClassifier: Bool,
-        aneClassifierHead: ANEGenerationClassifierHead?,
-        aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?,
         vocabSize: Int,
         stepRMSWorkspace: borrowing RMSNorm.Workspace
     ) throws(GenerationError) -> (TokenID, TokenID) {
-        if outputHeadBackend == .aneRMSNormClassifier {
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("two-step ANE fused output-head backend requested without compiled head")
-            }
-            return try aneRMSNormClassifierHead.selectArgmaxPair(
+        switch outputHead {
+        case .aneRMSNormClassifier(let head):
+            return try head.selectArgmaxPair(
                 rawInputA: activationA,
                 rawInputB: activationB
             )
+        case .cpuSgemm, .stagedCPU, .aneClassifier:
+            break
         }
 
         return (
             try Self.selectTokenFromActivation(
                 activationA,
                 strategy: strategy,
-                outputHeadBackend: outputHeadBackend,
+                outputHead: outputHead,
                 rmsFinal: rmsFinal,
                 stepNorm: stepNorm,
                 stepLogits: stepLogits,
                 embedding: embedding,
                 classifier: classifier,
                 sharedClassifier: sharedClassifier,
-                aneClassifierHead: aneClassifierHead,
-                aneRMSNormClassifierHead: aneRMSNormClassifierHead,
                 vocabSize: vocabSize,
                 stepRMSWorkspace: stepRMSWorkspace
             ),
             try Self.selectTokenFromActivation(
                 activationB,
                 strategy: strategy,
-                outputHeadBackend: outputHeadBackend,
+                outputHead: outputHead,
                 rmsFinal: rmsFinal,
                 stepNorm: stepNorm,
                 stepLogits: stepLogits,
                 embedding: embedding,
                 classifier: classifier,
                 sharedClassifier: sharedClassifier,
-                aneClassifierHead: aneClassifierHead,
-                aneRMSNormClassifierHead: aneRMSNormClassifierHead,
                 vocabSize: vocabSize,
                 stepRMSWorkspace: stepRMSWorkspace
             )
@@ -2114,10 +2085,9 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
     private let verifyLogits: TensorBuffer
     private let stepRMSWorkspace: RMSNorm.Workspace
     private let verifyRMSWorkspace: RMSNorm.Workspace
-    private let outputHeadBackend: GenerationOutputHeadBackend
-    private let cpuExactStagedHead: CPUStagedExactGenerationOutputHead?
-    private let aneClassifierHead: ANEGenerationClassifierHead?
-    private let aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
+    /// Output head, presence-typed against its backend.
+    private let outputHead: GenerationOutputHeadSelection
+    private var outputHeadBackend: GenerationOutputHeadBackend { outputHead.backend }
     private var decodeHandles: [DecodeSurfaceHandles]
     private var inferenceHandles: [InferenceSurfaceHandles]
     private var decodeState: DecodeState
@@ -2170,21 +2140,7 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
         let classifier = sharedClassifier
             ? TensorBuffer(count: 0, zeroed: true)
             : GenerationWeightCloner.cloneTensor(weights.classifier)
-        let aneClassifierHead = try Self.makeANEClassifierHead(
-            outputHeadBackend: outputHeadBackend,
-            vocabSize: vocabSize,
-            sharedClassifier: sharedClassifier,
-            embedding: embedding,
-            classifier: classifier
-        )
-        let cpuExactStagedHead = try Self.makeCPUExactStagedHead(
-            outputHeadBackend: outputHeadBackend,
-            vocabSize: vocabSize,
-            sharedClassifier: sharedClassifier,
-            embedding: embedding,
-            classifier: classifier
-        )
-        let aneRMSNormClassifierHead = try Self.makeANERMSNormClassifierHead(
+        let outputHead = try Self.makeOutputHead(
             outputHeadBackend: outputHeadBackend,
             vocabSize: vocabSize,
             sharedClassifier: sharedClassifier,
@@ -2220,10 +2176,7 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
         self.verifyLogits = TensorBuffer(count: vocabSize * ModelConfig.seqLen, zeroed: true)
         self.stepRMSWorkspace = RMSNorm.Workspace(seqLen: 1)
         self.verifyRMSWorkspace = RMSNorm.Workspace(seqLen: ModelConfig.seqLen)
-        self.outputHeadBackend = outputHeadBackend
-        self.cpuExactStagedHead = cpuExactStagedHead
-        self.aneClassifierHead = aneClassifierHead
-        self.aneRMSNormClassifierHead = aneRMSNormClassifierHead
+        self.outputHead = outputHead
         self.decodeHandles = decodeHandles
         self.inferenceHandles = inferenceHandles
         self.decodeState = decodeState
@@ -2316,89 +2269,70 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
         }
     }
 
-    private static func makeANEClassifierHead(
-        outputHeadBackend: GenerationOutputHeadBackend,
-        vocabSize: Int,
-        sharedClassifier: Bool,
-        embedding: borrowing TensorBuffer,
-        classifier: borrowing TensorBuffer
-    ) throws(GenerationError) -> ANEGenerationClassifierHead? {
-        switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
-        case .aneClassifier:
-            if sharedClassifier {
-                return try ANEGenerationClassifierHead(classifierWeights: embedding, vocabSize: vocabSize)
-            }
-            return try ANEGenerationClassifierHead(classifierWeights: classifier, vocabSize: vocabSize)
-        case .aneRMSNormClassifier:
-            return nil
-        }
-    }
-
-    private static func makeCPUExactStagedHead(
-        outputHeadBackend: GenerationOutputHeadBackend,
-        vocabSize: Int,
-        sharedClassifier: Bool,
-        embedding: borrowing TensorBuffer,
-        classifier: borrowing TensorBuffer
-    ) throws(GenerationError) -> CPUStagedExactGenerationOutputHead? {
-        switch outputHeadBackend {
-        case .cpu, .aneClassifier, .aneRMSNormClassifier, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
-        case .cpuExactStaged:
-            if sharedClassifier {
-                return try CPUStagedExactGenerationOutputHead(
-                    classifierWeights: embedding,
-                    vocabSize: vocabSize,
-                    layoutStrategy: .contiguous(shardSize: 1024)
-                )
-            }
-            return try CPUStagedExactGenerationOutputHead(
-                classifierWeights: classifier,
-                vocabSize: vocabSize,
-                layoutStrategy: .contiguous(shardSize: 1024)
-            )
-        case .cpuExactClustered:
-            if sharedClassifier {
-                return try CPUStagedExactGenerationOutputHead(
-                    classifierWeights: embedding,
-                    vocabSize: vocabSize,
-                    layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
-                )
-            }
-            return try CPUStagedExactGenerationOutputHead(
-                classifierWeights: classifier,
-                vocabSize: vocabSize,
-                layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
-            )
-        }
-    }
-
-    private static func makeANERMSNormClassifierHead(
+    /// Compiles exactly the output head the requested backend needs; the
+    /// returned selection is presence-typed, so consumers never face a
+    /// backend whose head failed to exist.
+    private static func makeOutputHead(
         outputHeadBackend: GenerationOutputHeadBackend,
         vocabSize: Int,
         sharedClassifier: Bool,
         rmsFinal: borrowing TensorBuffer,
         embedding: borrowing TensorBuffer,
         classifier: borrowing TensorBuffer
-    ) throws(GenerationError) -> ANEGenerationRMSNormClassifierHead? {
+    ) throws(GenerationError) -> GenerationOutputHeadSelection {
         switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .aneClassifier, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
+        case .cpu, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+            return .cpuSgemm(outputHeadBackend)
+        case .aneClassifier:
+            if sharedClassifier {
+                return .aneClassifier(try ANEGenerationClassifierHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize
+                ))
+            }
+            return .aneClassifier(try ANEGenerationClassifierHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize
+            ))
         case .aneRMSNormClassifier:
             if sharedClassifier {
-                return try ANEGenerationRMSNormClassifierHead(
+                return .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                     rmsFinal: rmsFinal,
                     classifierWeights: embedding,
                     vocabSize: vocabSize
-                )
+                ))
             }
-            return try ANEGenerationRMSNormClassifierHead(
+            return .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                 rmsFinal: rmsFinal,
                 classifierWeights: classifier,
                 vocabSize: vocabSize
-            )
+            ))
+        case .cpuExactStaged:
+            if sharedClassifier {
+                return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize,
+                    layoutStrategy: .contiguous(shardSize: 1024)
+                ))
+            }
+            return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize,
+                layoutStrategy: .contiguous(shardSize: 1024)
+            ))
+        case .cpuExactClustered:
+            if sharedClassifier {
+                return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize,
+                    layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
+                ))
+            }
+            return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize,
+                layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
+            ))
         }
     }
 
@@ -2562,8 +2496,10 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
         }
 
         stepLogits.zero()
-        switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+        switch outputHead {
+        case .cpuSgemm, .stagedCPU:
+            // Full-logits projection always runs the FP32 classifier, even for
+            // staged heads: they only accelerate argmax selection.
             stepLogits.withUnsafeMutablePointer { logitsPtr in
                 classifierPointer { clsPtr in
                     stepNorm.withUnsafePointer { normPtr in
@@ -2586,16 +2522,10 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
                     }
                 }
             }
-        case .aneClassifier:
-            guard let aneClassifierHead else {
-                throw .runtimeFailure("ANE classifier backend requested without compiled head")
-            }
-            try aneClassifierHead.project(normalizedInput: stepNorm, logits: stepLogits)
-        case .aneRMSNormClassifier:
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("ANE fused output-head backend requested without compiled head")
-            }
-            try aneRMSNormClassifierHead.project(rawInput: xCur, logits: stepLogits)
+        case .aneClassifier(let head):
+            try head.project(normalizedInput: stepNorm, logits: stepLogits)
+        case .aneRMSNormClassifier(let head):
+            try head.project(rawInput: xCur, logits: stepLogits)
         }
 
         logitsLatencyMs += GenerationClock.milliseconds(start: logitsStart, end: GenerationClock.now())
@@ -2624,8 +2554,11 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
         }
 
         let token: TokenID
-        switch outputHeadBackend {
-        case .cpu:
+        switch outputHead {
+        case .cpuSgemm:
+            // Every CPU-classifier backend (including deferred and tiled
+            // variants) classifies via sgemm in this model.
+            // beta=0.0 means sgemm overwrites C entirely — no pre-zeroing needed
             stepLogits.zero()
             stepLogits.withUnsafeMutablePointer { logitsPtr in
                 classifierPointer { clsPtr in
@@ -2650,52 +2583,12 @@ public struct ANEDirectGenerationModel: ~Copyable, DirectTokenSelectingLanguageM
                 }
             }
             token = try selectToken(from: stepLogits, strategy: strategy)
-        case .cpuExactStaged:
-            guard let cpuExactStagedHead else {
-                throw .runtimeFailure("staged exact CPU output head requested without staged head")
-            }
-            token = try cpuExactStagedHead.selectArgmax(normalizedInput: stepNorm)
-        case .cpuExactClustered:
-            guard let cpuExactStagedHead else {
-                throw .runtimeFailure("clustered exact CPU output head requested without staged head")
-            }
-            token = try cpuExactStagedHead.selectArgmax(normalizedInput: stepNorm)
-        case .aneClassifier:
-            guard let aneClassifierHead else {
-                throw .runtimeFailure("ANE classifier backend requested without compiled head")
-            }
-            token = try aneClassifierHead.selectArgmax(normalizedInput: stepNorm)
-        case .aneRMSNormClassifier:
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("ANE fused output-head backend requested without compiled head")
-            }
-            token = try aneRMSNormClassifierHead.selectArgmax(rawInput: xCur)
-        case .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            // Fall through to CPU sgemm path
-            stepLogits.zero()
-            stepLogits.withUnsafeMutablePointer { logitsPtr in
-                classifierPointer { clsPtr in
-                    stepNorm.withUnsafePointer { normPtr in
-                        BLAS.sgemm(
-                            CblasRowMajor,
-                            CblasNoTrans,
-                            CblasNoTrans,
-                            m: Int32(vocabSize),
-                            n: 1,
-                            k: Int32(ModelConfig.dim),
-                            alpha: 1.0,
-                            a: clsPtr,
-                            lda: Int32(ModelConfig.dim),
-                            b: normPtr,
-                            ldb: 1,
-                            beta: 0.0,
-                            c: logitsPtr,
-                            ldc: 1
-                        )
-                    }
-                }
-            }
-            token = try selectToken(from: stepLogits, strategy: strategy)
+        case .stagedCPU(let head):
+            token = try head.selectArgmax(normalizedInput: stepNorm)
+        case .aneClassifier(let head):
+            token = try head.selectArgmax(normalizedInput: stepNorm)
+        case .aneRMSNormClassifier(let head):
+            token = try head.selectArgmax(rawInput: xCur)
         }
 
         logitsLatencyMs += GenerationClock.milliseconds(start: logitsStart, end: GenerationClock.now())
@@ -2781,10 +2674,9 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
     private let stepNorm: TensorBuffer
     private let stepLogits: TensorBuffer
     private let stepRMSWorkspace: RMSNorm.Workspace
-    private let outputHeadBackend: GenerationOutputHeadBackend
-    private let cpuExactStagedHead: CPUStagedExactGenerationOutputHead?
-    private let aneClassifierHead: ANEGenerationClassifierHead?
-    private let aneRMSNormClassifierHead: ANEGenerationRMSNormClassifierHead?
+    /// Output head, presence-typed against its backend.
+    private let outputHead: GenerationOutputHeadSelection
+    private var outputHeadBackend: GenerationOutputHeadBackend { outputHead.backend }
     private let sharedOutputHeadWeights: SharedReadOnlyOutputHeadWeights
     private var activationA: TensorBuffer
     private var activationB: TensorBuffer
@@ -2880,22 +2772,7 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
             : (shareReadOnlyWeights
                 ? GenerationWeightCloner.shareTensor(sharedOutputHeadWeights.classifier)
                 : GenerationWeightCloner.cloneTensor(weights.classifier))
-        let aneClassifierHead = try Self.makeANEClassifierHead(
-            outputHeadBackend: outputHeadBackend,
-            vocabSize: vocabSize,
-            sharedClassifier: sharedClassifier,
-            embedding: embedding,
-            classifier: classifier,
-            laneSpatial: outputHeadLaneSpatial
-        )
-        let cpuExactStagedHead = try Self.makeCPUExactStagedHead(
-            outputHeadBackend: outputHeadBackend,
-            vocabSize: vocabSize,
-            sharedClassifier: sharedClassifier,
-            embedding: embedding,
-            classifier: classifier
-        )
-        let aneRMSNormClassifierHead = try Self.makeANERMSNormClassifierHead(
+        let outputHead = try Self.makeOutputHead(
             outputHeadBackend: outputHeadBackend,
             vocabSize: vocabSize,
             sharedClassifier: sharedClassifier,
@@ -2993,10 +2870,7 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
         self.stepNorm = TensorBuffer(count: ModelConfig.dim, zeroed: true)
         self.stepLogits = TensorBuffer(count: vocabSize, zeroed: true)
         self.stepRMSWorkspace = RMSNorm.Workspace(seqLen: 1)
-        self.outputHeadBackend = outputHeadBackend
-        self.cpuExactStagedHead = cpuExactStagedHead
-        self.aneClassifierHead = aneClassifierHead
-        self.aneRMSNormClassifierHead = aneRMSNormClassifierHead
+        self.outputHead = outputHead
         self.sharedOutputHeadWeights = sharedOutputHeadWeights
         self.activationA = TensorBuffer(count: ModelConfig.dim, zeroed: true)
         self.activationB = TensorBuffer(count: ModelConfig.dim, zeroed: true)
@@ -3088,75 +2962,10 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
         }
     }
 
-    private static func makeANEClassifierHead(
-        outputHeadBackend: GenerationOutputHeadBackend,
-        vocabSize: Int,
-        sharedClassifier: Bool,
-        embedding: borrowing TensorBuffer,
-        classifier: borrowing TensorBuffer,
-        laneSpatial: Int
-    ) throws(GenerationError) -> ANEGenerationClassifierHead? {
-        switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
-        case .aneClassifier:
-            if sharedClassifier {
-                return try ANEGenerationClassifierHead(
-                    classifierWeights: embedding,
-                    vocabSize: vocabSize,
-                    laneSpatial: laneSpatial
-                )
-            }
-            return try ANEGenerationClassifierHead(
-                classifierWeights: classifier,
-                vocabSize: vocabSize,
-                laneSpatial: laneSpatial
-            )
-        case .aneRMSNormClassifier:
-            return nil
-        }
-    }
-
-    private static func makeCPUExactStagedHead(
-        outputHeadBackend: GenerationOutputHeadBackend,
-        vocabSize: Int,
-        sharedClassifier: Bool,
-        embedding: borrowing TensorBuffer,
-        classifier: borrowing TensorBuffer
-    ) throws(GenerationError) -> CPUStagedExactGenerationOutputHead? {
-        switch outputHeadBackend {
-        case .cpu, .aneClassifier, .aneRMSNormClassifier, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
-        case .cpuExactStaged:
-            if sharedClassifier {
-                return try CPUStagedExactGenerationOutputHead(
-                    classifierWeights: embedding,
-                    vocabSize: vocabSize,
-                    layoutStrategy: .contiguous(shardSize: 1024)
-                )
-            }
-            return try CPUStagedExactGenerationOutputHead(
-                classifierWeights: classifier,
-                vocabSize: vocabSize,
-                layoutStrategy: .contiguous(shardSize: 1024)
-            )
-        case .cpuExactClustered:
-            if sharedClassifier {
-                return try CPUStagedExactGenerationOutputHead(
-                    classifierWeights: embedding,
-                    vocabSize: vocabSize,
-                    layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
-                )
-            }
-            return try CPUStagedExactGenerationOutputHead(
-                classifierWeights: classifier,
-                vocabSize: vocabSize,
-                layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
-            )
-        }
-    }
-
-    private static func makeANERMSNormClassifierHead(
+    /// Compiles exactly the output head the requested backend needs; the
+    /// returned selection is presence-typed, so consumers never face a
+    /// backend whose head failed to exist.
+    private static func makeOutputHead(
         outputHeadBackend: GenerationOutputHeadBackend,
         vocabSize: Int,
         sharedClassifier: Bool,
@@ -3164,25 +2973,64 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
         embedding: borrowing TensorBuffer,
         classifier: borrowing TensorBuffer,
         laneSpatial: Int
-    ) throws(GenerationError) -> ANEGenerationRMSNormClassifierHead? {
+    ) throws(GenerationError) -> GenerationOutputHeadSelection {
         switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .aneClassifier, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
-            return nil
+        case .cpu, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+            return .cpuSgemm(outputHeadBackend)
+        case .aneClassifier:
+            if sharedClassifier {
+                return .aneClassifier(try ANEGenerationClassifierHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize,
+                    laneSpatial: laneSpatial
+                ))
+            }
+            return .aneClassifier(try ANEGenerationClassifierHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize,
+                laneSpatial: laneSpatial
+            ))
         case .aneRMSNormClassifier:
             if sharedClassifier {
-                return try ANEGenerationRMSNormClassifierHead(
+                return .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                     rmsFinal: rmsFinal,
                     classifierWeights: embedding,
                     vocabSize: vocabSize,
                     laneSpatial: laneSpatial
-                )
+                ))
             }
-            return try ANEGenerationRMSNormClassifierHead(
+            return .aneRMSNormClassifier(try ANEGenerationRMSNormClassifierHead(
                 rmsFinal: rmsFinal,
                 classifierWeights: classifier,
                 vocabSize: vocabSize,
                 laneSpatial: laneSpatial
-            )
+            ))
+        case .cpuExactStaged:
+            if sharedClassifier {
+                return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize,
+                    layoutStrategy: .contiguous(shardSize: 1024)
+                ))
+            }
+            return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize,
+                layoutStrategy: .contiguous(shardSize: 1024)
+            ))
+        case .cpuExactClustered:
+            if sharedClassifier {
+                return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                    classifierWeights: embedding,
+                    vocabSize: vocabSize,
+                    layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
+                ))
+            }
+            return .stagedCPU(try CPUStagedExactGenerationOutputHead(
+                classifierWeights: classifier,
+                vocabSize: vocabSize,
+                layoutStrategy: .clustered(clusterCount: 32, projectionDimensionCount: 24, iterations: 2)
+            ))
         }
     }
 
@@ -3390,8 +3238,10 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
         }
 
         stepLogits.zero()
-        switch outputHeadBackend {
-        case .cpu, .cpuExactStaged, .cpuExactClustered, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled:
+        switch outputHead {
+        case .cpuSgemm, .stagedCPU:
+            // Full-logits projection always runs the FP32 classifier, even for
+            // staged heads: they only accelerate argmax selection.
             stepLogits.withUnsafeMutablePointer { logitsPtr in
                 classifierPointer { clsPtr in
                     stepNorm.withUnsafePointer { normPtr in
@@ -3414,19 +3264,13 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
                     }
                 }
             }
-        case .aneClassifier:
-            guard let aneClassifierHead else {
-                throw .runtimeFailure("ANE classifier backend requested without compiled head")
-            }
-            try aneClassifierHead.project(normalizedInput: stepNorm, logits: stepLogits)
-        case .aneRMSNormClassifier:
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("ANE fused output-head backend requested without compiled head")
-            }
+        case .aneClassifier(let head):
+            try head.project(normalizedInput: stepNorm, logits: stepLogits)
+        case .aneRMSNormClassifier(let head):
             if currentActivationIsA {
-                try aneRMSNormClassifierHead.project(rawInput: activationA, logits: stepLogits)
+                try head.project(rawInput: activationA, logits: stepLogits)
             } else {
-                try aneRMSNormClassifierHead.project(rawInput: activationB, logits: stepLogits)
+                try head.project(rawInput: activationB, logits: stepLogits)
             }
         }
 
@@ -3473,65 +3317,20 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
         }
 
         let token: TokenID
-        switch outputHeadBackend {
-        case .cpu:
-            stepLogits.zero()
-            stepLogits.withUnsafeMutablePointer { logitsPtr in
-                classifierPointer { clsPtr in
-                    stepNorm.withUnsafePointer { normPtr in
-                        BLAS.sgemm(
-                            CblasRowMajor,
-                            CblasNoTrans,
-                            CblasNoTrans,
-                            m: Int32(vocabSize),
-                            n: 1,
-                            k: Int32(ModelConfig.dim),
-                            alpha: 1.0,
-                            a: clsPtr,
-                            lda: Int32(ModelConfig.dim),
-                            b: normPtr,
-                            ldb: 1,
-                            beta: 0.0,
-                            c: logitsPtr,
-                            ldc: 1
-                        )
-                    }
-                }
-            }
-            token = try selectToken(from: stepLogits, strategy: strategy)
-        case .cpuExactStaged:
-            guard let cpuExactStagedHead else {
-                throw .runtimeFailure("staged exact CPU output head requested without staged head")
-            }
-            token = try cpuExactStagedHead.selectArgmax(normalizedInput: stepNorm)
-        case .cpuExactClustered:
-            guard let cpuExactStagedHead else {
-                throw .runtimeFailure("clustered exact CPU output head requested without staged head")
-            }
-            token = try cpuExactStagedHead.selectArgmax(normalizedInput: stepNorm)
-        case .aneClassifier:
-            guard let aneClassifierHead else {
-                throw .runtimeFailure("ANE classifier backend requested without compiled head")
-            }
-            token = try aneClassifierHead.selectArgmax(normalizedInput: stepNorm)
-        case .aneRMSNormClassifier:
-            guard let aneRMSNormClassifierHead else {
-                throw .runtimeFailure("ANE fused output-head backend requested without compiled head")
-            }
+        switch outputHead {
+        case .stagedCPU(let head):
+            token = try head.selectArgmax(normalizedInput: stepNorm)
+        case .aneClassifier(let head):
+            token = try head.selectArgmax(normalizedInput: stepNorm)
+        case .aneRMSNormClassifier(let head):
             if currentActivationIsA {
-                token = try aneRMSNormClassifierHead.selectArgmax(rawInput: activationA)
+                token = try head.selectArgmax(rawInput: activationA)
             } else {
-                token = try aneRMSNormClassifierHead.selectArgmax(rawInput: activationB)
+                token = try head.selectArgmax(rawInput: activationB)
             }
-        case .cpuThenANE:
-            // If deferred ANE head is ready, use it; otherwise fall through to CPU sgemm
-            if let readyHead = deferredANEHead?.readyHead() {
-                if currentActivationIsA {
-                    token = try readyHead.selectArgmax(rawInput: activationA)
-                } else {
-                    token = try readyHead.selectArgmax(rawInput: activationB)
-                }
-            } else {
+        case .cpuSgemm(let backend):
+            switch backend {
+            case .cpu:
                 stepLogits.zero()
                 stepLogits.withUnsafeMutablePointer { logitsPtr in
                     classifierPointer { clsPtr in
@@ -3556,44 +3355,82 @@ public struct ANERecurrentGenerationModel: ~Copyable, DirectTokenSelectingLangua
                     }
                 }
                 token = try selectToken(from: stepLogits, strategy: strategy)
-            }
-        case .cpuPartitionedArgmax:
-            // Partitioned argmax with Cauchy-Schwarz block pruning (greedy only)
-            var skippedBlocks = 0
-            let tokenIndex = partitionedLogitsScratch.withUnsafeMutablePointer { scratchPtr in
-                classifierPointer { clsPtr in
-                    stepNorm.withUnsafePointer { normPtr in
-                        blockMaxNorms.withUnsafeBufferPointer { normsPtr in
-                            PartitionedArgmax.compute(
-                                classifier: clsPtr,
-                                input: normPtr,
-                                logitsScratch: scratchPtr,
-                                blockMaxNorms: normsPtr.baseAddress!,
-                                vocabSize: vocabSize,
-                                dim: ModelConfig.dim,
-                                blockSize: PartitionedArgmax.defaultBlockSize,
-                                skippedBlocks: &skippedBlocks
-                            )
+            case .cpuThenANE:
+                // If deferred ANE head is ready, use it; otherwise fall through to CPU sgemm
+                if let readyHead = deferredANEHead?.readyHead() {
+                    if currentActivationIsA {
+                        token = try readyHead.selectArgmax(rawInput: activationA)
+                    } else {
+                        token = try readyHead.selectArgmax(rawInput: activationB)
+                    }
+                } else {
+                    stepLogits.zero()
+                    stepLogits.withUnsafeMutablePointer { logitsPtr in
+                        classifierPointer { clsPtr in
+                            stepNorm.withUnsafePointer { normPtr in
+                                BLAS.sgemm(
+                                    CblasRowMajor,
+                                    CblasNoTrans,
+                                    CblasNoTrans,
+                                    m: Int32(vocabSize),
+                                    n: 1,
+                                    k: Int32(ModelConfig.dim),
+                                    alpha: 1.0,
+                                    a: clsPtr,
+                                    lda: Int32(ModelConfig.dim),
+                                    b: normPtr,
+                                    ldb: 1,
+                                    beta: 0.0,
+                                    c: logitsPtr,
+                                    ldc: 1
+                                )
+                            }
+                        }
+                    }
+                    token = try selectToken(from: stepLogits, strategy: strategy)
+                }
+            case .cpuPartitionedArgmax:
+                // Partitioned argmax with Cauchy-Schwarz block pruning (greedy only)
+                var skippedBlocks = 0
+                let tokenIndex = partitionedLogitsScratch.withUnsafeMutablePointer { scratchPtr in
+                    classifierPointer { clsPtr in
+                        stepNorm.withUnsafePointer { normPtr in
+                            blockMaxNorms.withUnsafeBufferPointer { normsPtr in
+                                PartitionedArgmax.compute(
+                                    classifier: clsPtr,
+                                    input: normPtr,
+                                    logitsScratch: scratchPtr,
+                                    blockMaxNorms: normsPtr.baseAddress!,
+                                    vocabSize: vocabSize,
+                                    dim: ModelConfig.dim,
+                                    blockSize: PartitionedArgmax.defaultBlockSize,
+                                    skippedBlocks: &skippedBlocks
+                                )
+                            }
                         }
                     }
                 }
-            }
-            token = TokenID(tokenIndex)
-        case .cpuFP16Tiled:
-            guard classifierFP16.count > 0 else {
-                throw .runtimeFailure("FP16 tiled classifier backend requested without FP16 weights")
-            }
-            let tokenIndex = classifierFP16.withUnsafePointer { fp16Ptr in
-                stepNorm.withUnsafePointer { normPtr in
-                    FP16TiledClassifier.tiledMatvecArgmax(
-                        weights: fp16Ptr,
-                        input: normPtr,
-                        vocabSize: vocabSize,
-                        dim: ModelConfig.dim
-                    )
+                token = TokenID(tokenIndex)
+            case .cpuFP16Tiled:
+                guard classifierFP16.count > 0 else {
+                    throw .runtimeFailure("FP16 tiled classifier backend requested without FP16 weights")
                 }
+                let tokenIndex = classifierFP16.withUnsafePointer { fp16Ptr in
+                    stepNorm.withUnsafePointer { normPtr in
+                        FP16TiledClassifier.tiledMatvecArgmax(
+                            weights: fp16Ptr,
+                            input: normPtr,
+                            vocabSize: vocabSize,
+                            dim: ModelConfig.dim
+                        )
+                    }
+                }
+                token = TokenID(tokenIndex)
+            case .cpuExactStaged, .cpuExactClustered, .aneClassifier, .aneRMSNormClassifier:
+                // Unreachable: the selection payload pairs each of these backends
+                // with its compiled head, so they never land on a CPU-classifier route.
+                throw .runtimeFailure("output-head backend \(backend) requested without compiled head")
             }
-            token = TokenID(tokenIndex)
         }
 
         logitsLatencyMs += GenerationClock.milliseconds(start: logitsStart, end: GenerationClock.now())

--- a/Sources/EspressoGenerate/CLI.swift
+++ b/Sources/EspressoGenerate/CLI.swift
@@ -829,7 +829,7 @@ func cliUsageText() -> String {
           --benchmark-generate Reuse one Espresso engine and report warm generate metrics using --compare-warmup/--compare-iterations
           --raw-prompt         Encode the prompt verbatim (skip the Qwen2.5-Instruct chat wrap)
           --no-hybrid-fallback Fail instead of falling back from the ANE hybrid decode path
-                           Chat always sets ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK=1
+                           Chat never falls back to CPU decode
       -h, --help               Show this help
 
     Environment:

--- a/Sources/EspressoGenerate/CLI.swift
+++ b/Sources/EspressoGenerate/CLI.swift
@@ -414,6 +414,7 @@ struct ResolvedInvocation {
     let seed: Int
     let outputDir: String?
     let rawPrompt: Bool
+    let decodePathOptions: DecodePathOptions
 
     init(
         config: MultiModelConfig,
@@ -434,7 +435,8 @@ struct ResolvedInvocation {
         allowBootstrap: Bool,
         seed: Int,
         outputDir: String?,
-        rawPrompt: Bool = false
+        rawPrompt: Bool = false,
+        decodePathOptions: DecodePathOptions? = nil
     ) {
         self.config = config
         self.bundlePath = bundlePath
@@ -455,6 +457,9 @@ struct ResolvedInvocation {
         self.seed = seed
         self.outputDir = outputDir
         self.rawPrompt = rawPrompt
+        self.decodePathOptions = decodePathOptions ?? DecodePathPolicy.optionsFromEnvironment(
+            ProcessInfo.processInfo.environment
+        )
     }
 }
 
@@ -484,7 +489,8 @@ extension ResolvedInvocation {
             allowBootstrap: allowBootstrap,
             seed: seed,
             outputDir: outputDir ?? self.outputDir,
-            rawPrompt: rawPrompt
+            rawPrompt: rawPrompt,
+            decodePathOptions: decodePathOptions
         )
     }
 }
@@ -651,9 +657,6 @@ private final class LockedValueBox<Value>: @unchecked Sendable {
 }
 
 func applyCLIExperimentEnvironment(_ options: Options) {
-    if options.disableHybridFallback || chatForcesHybridFallbackDisable(options) {
-        setenv("ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK", "1", 1)
-    }
     if options.rawPrompt {
         setenv("ESPRESSO_RAW_PROMPT", "1", 1)
     }
@@ -673,6 +676,20 @@ func applyCLIExperimentEnvironment(_ options: Options) {
     default:
         setenv("ESPRESSO_GPT2_USE_RMS_NORM", "0", 1)
     }
+}
+
+/// Decode-path steering passed explicitly to engine entry points. Environment
+/// variables set externally remain the fallback for flags the CLI does not own;
+/// CLI intent wins over them.
+func cliDecodePathOptions(
+    _ options: Options,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) -> DecodePathOptions {
+    var decodeOptions = DecodePathPolicy.optionsFromEnvironment(environment)
+    if options.disableHybridFallback || chatForcesHybridFallbackDisable(options) {
+        decodeOptions.disableHybridFallback = true
+    }
+    return decodeOptions
 }
 
 private let posixLocale = Locale(identifier: "en_US_POSIX")
@@ -1245,7 +1262,8 @@ func resolveInvocation(from options: Options, demoDefaults: DemoDefaults, comman
             allowBootstrap: options.allowBootstrap,
             seed: options.seed,
             outputDir: options.outputDir,
-            rawPrompt: options.rawPrompt
+            rawPrompt: options.rawPrompt,
+            decodePathOptions: cliDecodePathOptions(options)
         )
     }
 
@@ -1296,7 +1314,8 @@ func resolveInvocation(from options: Options, demoDefaults: DemoDefaults, comman
         allowBootstrap: options.allowBootstrap,
         seed: options.seed,
         outputDir: options.outputDir,
-        rawPrompt: options.rawPrompt
+        rawPrompt: options.rawPrompt,
+        decodePathOptions: cliDecodePathOptions(options)
     )
 }
 
@@ -1406,7 +1425,8 @@ private func runEspressoGeneration(
             tokenLatenciesMs.append(step.tokenLatencyMs)
             totalTimeMs = step.elapsedMs
             onStep?(step)
-        }
+        },
+        options: invocation.decodePathOptions
     )
     let compileStatsAfter = ANECompileStats.snapshot()
     let compileStatsDelta = compileStatsAfter.subtracting(compileStatsBefore)
@@ -2122,7 +2142,8 @@ private func runLiveCompare(invocation: ResolvedInvocation, defaults: DemoDefaul
                 rawPrompt: invocation.rawPrompt
             ),
             maxTokens: min(invocation.maxTokens, 4),
-            temperature: invocation.temperature
+            temperature: invocation.temperature,
+            options: invocation.decodePathOptions
         )
     }.power
 
@@ -2945,7 +2966,10 @@ private func runChatVsMLX(
 
     var engine = try makeEspressoEngine(invocation: invocation)
     let compileStarted = DispatchTime.now().uptimeNanoseconds
-    try engine.precompileHybridDecode(covering: invocation.config.maxSeq)
+    try engine.precompileHybridDecode(
+        covering: invocation.config.maxSeq,
+        options: invocation.decodePathOptions
+    )
     let espressoCompileMs = millisecondsSince(compileStarted)
     let tokenizer = try loadTokenizer(config: invocation.config, tokenizerDir: invocation.tokenizerDir)
     var session = ChatSession(system: options.systemPrompt ?? QwenInstructPrompt.systemBanner)
@@ -3188,7 +3212,8 @@ private func runChatVsMLXEspressoLane(
                     writePlain(tokenizer.decode([Int(step.token)]), "")
                 }
             },
-            isCancelled: { cancel.isCancelled }
+            isCancelled: { cancel.isCancelled },
+            options: invocation.decodePathOptions
         )
     }
     try assertChatDecodePathIsHybrid(measured.result.decodePath)
@@ -3342,7 +3367,10 @@ private func plainLaneFooter(lane: LiveLaneSnapshot, focus: LaneWattFocus, capab
 private func runChat(invocation: ResolvedInvocation, options: Options, powerEnabled: Bool) throws -> Int32 {
     applyCLIExperimentEnvironment(options)
     var engine = try makeEspressoEngine(invocation: invocation)
-    try engine.precompileHybridDecode(covering: invocation.config.maxSeq)
+    try engine.precompileHybridDecode(
+        covering: invocation.config.maxSeq,
+        options: invocation.decodePathOptions
+    )
     let tokenizer = try loadTokenizer(config: invocation.config, tokenizerDir: invocation.tokenizerDir)
     var session = ChatSession(system: options.systemPrompt ?? QwenInstructPrompt.systemBanner)
     let sampling = resolvedSampling(command: .chat, options: options)
@@ -3468,7 +3496,8 @@ private func runChat(invocation: ResolvedInvocation, options: Options, powerEnab
                                 writePlain(tokenizer.decode([Int(step.token)]), terminator: "")
                             }
                         },
-                        isCancelled: { cancel.isCancelled }
+                        isCancelled: { cancel.isCancelled },
+                        options: invocation.decodePathOptions
                     )
                 }
                 let result = measured.result

--- a/Sources/RealModelInference/CompiledReadiness.swift
+++ b/Sources/RealModelInference/CompiledReadiness.swift
@@ -1,0 +1,91 @@
+import IOSurface
+
+/// Per-trunk compile readiness for the current engine session.
+///
+/// Replaces the former `compiled*` flag-and-conjunction family: a trunk is
+/// either `.notCompiled`, or `.compiled(runtime)` where the runtime was
+/// captured only after every program that trunk's decode loop requires became
+/// resident. Readiness checks switch over this enum exhaustively instead of
+/// re-deriving flag counts at each use site, and engine state transitions go
+/// through it — the ensure functions are the only writers.
+enum CompiledReadiness<Runtime> {
+    /// No programs are resident for this trunk yet.
+    case notCompiled
+    /// The trunk's validated runtime is resident and covers `runtime`'s bucket.
+    case compiled(Runtime)
+
+    /// The resident runtime, or `nil` when nothing is compiled.
+    var runtime: Runtime? {
+        switch self {
+        case .compiled(let runtime): runtime
+        case .notCompiled: nil
+        }
+    }
+}
+
+/// Programs required by the baseline (exact-CPU-routed ANE eval) decode loop.
+///
+/// Constructed only after every program the loop needs is resident, so a
+/// `.compiled` value proves the loop's former guard conjunction.
+struct BaselineCompiledRuntime {
+    /// Context bucket the programs were compiled for.
+    let bucket: Int
+    /// First-layer input surface the loop writes embeddings into.
+    let inputSurface: IOSurfaceRef
+}
+
+/// Programs required by the split-hybrid decode loop
+/// (ANE QKV → host attention → ANE FFN), shared by GPT-2 and llama sessions.
+struct SplitHybridCompiledRuntime {
+    /// Context bucket the programs were compiled for.
+    let bucket: Int
+    /// Output-head lane spatial; `> 0` once the head program is resident.
+    let headSpatial: Int
+
+    /// Captures the resident split-hybrid program facts, or `nil` unless every
+    /// program the loop requires is present. Llama sessions additionally
+    /// require one QK-norm weight entry per layer; pass `qKNormCount: nil` for
+    /// architectures without them.
+    init?(
+        bucket: Int,
+        layerCount: Int,
+        surfaceHandleCount: Int,
+        expectedLayerCount: Int,
+        headCount: Int,
+        qKNormCount: Int? = nil,
+        headSpatial: Int
+    ) {
+        guard layerCount == expectedLayerCount,
+              surfaceHandleCount == expectedLayerCount,
+              headCount == 1,
+              headSpatial > 0 else {
+            return nil
+        }
+        if let qKNormCount, qKNormCount != expectedLayerCount {
+            return nil
+        }
+        self.bucket = bucket
+        self.headSpatial = headSpatial
+    }
+}
+
+/// Programs required by the fused-hybrid decode loop (one ANE program per layer).
+struct FusedHybridCompiledRuntime {
+    /// Context bucket the programs were compiled for.
+    let bucket: Int
+
+    /// Captures the resident fused-hybrid program facts, or `nil` unless every
+    /// program the loop requires is present.
+    init?(
+        bucket: Int,
+        layerCount: Int,
+        surfaceHandleCount: Int,
+        expectedLayerCount: Int
+    ) {
+        guard layerCount == expectedLayerCount,
+              surfaceHandleCount == expectedLayerCount else {
+            return nil
+        }
+        self.bucket = bucket
+    }
+}

--- a/Sources/RealModelInference/DecodePathPolicy.swift
+++ b/Sources/RealModelInference/DecodePathPolicy.swift
@@ -1,0 +1,202 @@
+import ModelSupport
+
+/// Typed steering inputs for decode-path decisions.
+///
+/// Replaces direct process-environment reads scattered through the engine:
+/// every production decode-path decision starts from one snapshot of these
+/// options, produced either explicitly by an embedding host (CLI, benchmarks)
+/// or once at the bootstrap seam via ``DecodePathPolicy/optionsFromEnvironment(_:)``.
+public struct DecodePathOptions: Sendable, Equatable {
+    /// `ESPRESSO_FORCE_HYBRID_DECODE=1` — steer legacy CPU-routed artifacts onto an ANE trunk.
+    public var forceHybridDecode: Bool
+    /// `ESPRESSO_USE_CPU_EXACT_DECODE=1` — request the exact-CPU trunk outright.
+    public var useCPUExactDecode: Bool
+    /// `ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK=1` — refuse to leave the selected ANE
+    /// trunk; throw instead of downgrading.
+    public var disableHybridFallback: Bool
+    /// `DECODE_EVAL_FFN_ONLY=1` — decode-step kernels skip attention work (eval harness).
+    public var ffnOnlyEval: Bool
+
+    public init(
+        forceHybridDecode: Bool = false,
+        useCPUExactDecode: Bool = false,
+        disableHybridFallback: Bool = false,
+        ffnOnlyEval: Bool = false
+    ) {
+        self.forceHybridDecode = forceHybridDecode
+        self.useCPUExactDecode = useCPUExactDecode
+        self.disableHybridFallback = disableHybridFallback
+        self.ffnOnlyEval = ffnOnlyEval
+    }
+}
+
+/// What happens when a selected trunk cannot be served.
+public enum HybridFallbackPolicy: Sendable, Equatable {
+    /// Rerun the work on the lower trunk (hybrid fast-path failure falls back to baseline).
+    case rerunOnBaseline
+    /// Refuse to leave the selected trunk; raise `hybridFallbackDisabled` instead.
+    case disabled
+}
+
+/// Why a resolution landed on the exact-CPU trunk. Drives actionable errors when
+/// fallback to CPU is forbidden.
+public enum ExactCPURoutingSource: Sendable, Equatable {
+    /// `ESPRESSO_USE_CPU_EXACT_DECODE=1` asked for it.
+    case operatorRequest
+    /// The artifact declares `preferredDecodePath = exact_cpu` in metadata.json.
+    case artifactDeclaration
+    /// Legacy name-based routing for early Qwen artifacts without a declared path.
+    case legacyQwenNameRouting
+}
+
+/// The outcome of resolving decode-path policy for one llama serving session:
+/// the selected trunk, its fallback behavior, and the dispatch options consumed
+/// while running decode steps.
+public struct ResolvedDecodePlan: Sendable, Equatable {
+    /// Selected trunk: fused hybrid, split hybrid, or exact-CPU.
+    public let trunk: Trunk
+    /// Fallback behavior when the selected trunk cannot be served.
+    public let fallbackPolicy: HybridFallbackPolicy
+    /// Dispatch option handed to decode-step kernels.
+    public let ffnOnlyEval: Bool
+    /// Set when `trunk` is `.exactCPU`: which routing rule chose it.
+    public let cpuExactRoutingSource: ExactCPURoutingSource?
+
+    init(
+        trunk: Trunk,
+        fallbackPolicy: HybridFallbackPolicy,
+        ffnOnlyEval: Bool,
+        cpuExactRoutingSource: ExactCPURoutingSource?
+    ) {
+        self.trunk = trunk
+        self.fallbackPolicy = fallbackPolicy
+        self.ffnOnlyEval = ffnOnlyEval
+        self.cpuExactRoutingSource = cpuExactRoutingSource
+    }
+
+    public var allowsHybridFallback: Bool {
+        fallbackPolicy == .rerunOnBaseline
+    }
+}
+
+/// Pure decode-path decision logic: `(config, options)` → selected trunk +
+/// fallback policy + dispatch options. No process-global state is consulted;
+/// callers bootstrap options once via ``optionsFromEnvironment(_:)`` and pass
+/// explicit values wherever a host knows better than the environment.
+public enum DecodePathPolicy {
+    /// The single bootstrap seam: parse decode-path steering from raw
+    /// environment values. Explicit options beat these values; these values
+    /// remain the fallback when no option is set.
+    public static func optionsFromEnvironment(_ environment: [String: String]) -> DecodePathOptions {
+        DecodePathOptions(
+            forceHybridDecode: environment["ESPRESSO_FORCE_HYBRID_DECODE"] == "1",
+            useCPUExactDecode: environment["ESPRESSO_USE_CPU_EXACT_DECODE"] == "1",
+            disableHybridFallback: environment["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK"] == "1",
+            ffnOnlyEval: environment["DECODE_EVAL_FFN_ONLY"] == "1"
+        )
+    }
+
+    /// Whether the exact-CPU trunk is preferred for this configuration.
+    ///
+    /// Precedence mirrors the serving contract: an explicit hybrid force wins,
+    /// then an explicit CPU request, then the artifact's declared
+    /// `preferredDecodePath`, then legacy name-based Qwen routing.
+    public static func prefersCPUExactDecode(
+        config: MultiModelConfig,
+        options: DecodePathOptions
+    ) -> Bool {
+        if options.forceHybridDecode {
+            return false
+        }
+        if options.useCPUExactDecode {
+            return true
+        }
+        guard config.architecture == .llama else {
+            return false
+        }
+        // An artifact that states where it decodes is trusted over the name heuristic below.
+        if let declared = config.preferredDecodePath {
+            return declared == .exactCPU
+        }
+        // Legacy routing: early Qwen artifacts predate a working ANE path at these widths
+        // and are kept on the CPU oracle so old bundles do not change behaviour.
+        return ModelFamily.isQwenVariant(config)
+    }
+
+    /// Resolve the serving plan for a configuration under the given options.
+    ///
+    /// `fusedHybridPreferred` carries the fused-vs-split hybrid preference whose
+    /// own steering variables live outside this module's scope; the policy owns
+    /// the selection order (exact-CPU first, then fused hybrid, then split hybrid),
+    /// the fallback policy, and the dispatch options.
+    public static func resolve(
+        config: MultiModelConfig,
+        fusedHybridPreferred: Bool,
+        options: DecodePathOptions
+    ) -> ResolvedDecodePlan {
+        let fallbackPolicy: HybridFallbackPolicy = options.disableHybridFallback ? .disabled : .rerunOnBaseline
+        if let cpuSource = cpuExactRoutingSource(config: config, options: options) {
+            return ResolvedDecodePlan(
+                trunk: .exactCPU,
+                fallbackPolicy: fallbackPolicy,
+                ffnOnlyEval: options.ffnOnlyEval,
+                cpuExactRoutingSource: cpuSource
+            )
+        }
+        return ResolvedDecodePlan(
+            trunk: fusedHybridPreferred ? .fusedHybrid : .splitHybrid,
+            fallbackPolicy: fallbackPolicy,
+            ffnOnlyEval: options.ffnOnlyEval,
+            cpuExactRoutingSource: nil
+        )
+    }
+
+    private static func cpuExactRoutingSource(
+        config: MultiModelConfig,
+        options: DecodePathOptions
+    ) -> ExactCPURoutingSource? {
+        guard prefersCPUExactDecode(config: config, options: options) else {
+            return nil
+        }
+        if options.useCPUExactDecode {
+            return .operatorRequest
+        }
+        if config.preferredDecodePath == .exactCPU {
+            return .artifactDeclaration
+        }
+        return .legacyQwenNameRouting
+    }
+
+    /// Resolves the llama serving ``Trunk``, refusing to leave the ANE silently.
+    ///
+    /// With fallback disabled, landing on the pure-CPU trunk is a failure rather than a
+    /// quiet downgrade, and the thrown error names which policy chose CPU so the cause is
+    /// actionable instead of mysterious.
+    public static func resolvedTrunk(
+        config: MultiModelConfig,
+        fusedHybridPreferred: Bool,
+        options: DecodePathOptions
+    ) throws -> Trunk {
+        let plan = resolve(config: config, fusedHybridPreferred: fusedHybridPreferred, options: options)
+        guard plan.trunk == .exactCPU, plan.fallbackPolicy == .disabled else {
+            return plan.trunk
+        }
+        let reason: String
+        switch plan.cpuExactRoutingSource {
+        case .operatorRequest:
+            reason = "ESPRESSO_USE_CPU_EXACT_DECODE=1 explicitly requests the pure-CPU decode path"
+        case .artifactDeclaration:
+            reason = "the artifact declares preferredDecodePath=exact_cpu in metadata.json"
+        case .legacyQwenNameRouting, nil:
+            reason = """
+                model name "\(config.name)" matches the legacy Qwen CPU-exact routing policy \
+                and metadata.json does not declare preferredDecodePath; set \
+                preferredDecodePath=hybrid or ESPRESSO_FORCE_HYBRID_DECODE=1 to decode on the ANE
+                """
+        }
+        throw RealModelInferenceError.hybridFallbackDisabled(
+            stage: "llama trunk selection",
+            reason: reason
+        )
+    }
+}

--- a/Sources/RealModelInference/EmissionCore.swift
+++ b/Sources/RealModelInference/EmissionCore.swift
@@ -1,0 +1,183 @@
+import Foundation
+import ANETypes
+import ModelSupport
+
+/// Where the end-of-sequence token id comes from for one decode loop.
+///
+/// Injected per model family so no loop hardcodes an EOS source: GPT-2
+/// sessions pass the fixed tokenizer constant, llama sessions pass the
+/// artifact's optional `config.eosToken`.
+enum EOSPolicy: Sendable, Equatable {
+    /// One constant token id that always terminates decoding (GPT-2 family).
+    case fixed(Int)
+    /// The model config's optional `eosToken`; `nil` disables EOS termination.
+    case fromConfig(Int?)
+}
+
+/// Accumulator owning the four emission concerns shared by every decode loop:
+///
+/// 1. first-token latency capture,
+/// 2. tokens-per-second computation,
+/// 3. ``GenerationStep`` construction for `onStep` callbacks,
+/// 4. final ``GenerationResult`` assembly.
+///
+/// Loops keep their own KV-cache handling, speculative-draft logic, and
+/// early-return shapes; this type owns only how emitted tokens turn into
+/// telemetry and results. Per-token latencies measure emission-to-emission,
+/// starting from session start.
+struct EmissionCore {
+    /// Resolved end-of-sequence id under the injected policy, or `nil` when
+    /// this run never terminates early.
+    private(set) var eosTokenID: Int?
+
+    /// Session start clock used by every latency and rate computation.
+    private let startNanos: UInt64
+    /// Clock of the previous emission (initialized to session start).
+    private var lastEmissionNanos: UInt64
+    private var firstTokenLatencyMsValue = 0.0
+    private var firstTokenRecorded = false
+
+    /// Prompt plus every fully emitted token; the text carrier.
+    private(set) var allTokens: [TokenID]
+    /// Emitted output tokens; llama-family terminal tokens land here only.
+    private(set) var generatedTokens: [TokenID]
+    private(set) var tokenLatenciesMs: [Double]
+
+    private let promptTokens: [TokenID]
+    private let onStep: ((GenerationStep) -> Void)?
+    private let decodeText: ([Int]) -> String
+
+    init(
+        promptTokens: [TokenID],
+        capacity: Int,
+        eos: EOSPolicy,
+        onStep: ((GenerationStep) -> Void)?,
+        decodeText: @escaping ([Int]) -> String,
+        startNanos: UInt64 = DispatchTime.now().uptimeNanoseconds
+    ) {
+        self.eosTokenID = switch eos {
+        case .fixed(let tokenID): tokenID
+        case .fromConfig(let tokenID): tokenID
+        }
+        self.startNanos = startNanos
+        self.lastEmissionNanos = startNanos
+        self.allTokens = promptTokens
+        self.generatedTokens = []
+        self.generatedTokens.reserveCapacity(capacity)
+        self.tokenLatenciesMs = []
+        self.tokenLatenciesMs.reserveCapacity(capacity)
+        self.promptTokens = promptTokens
+        self.onStep = onStep
+        self.decodeText = decodeText
+    }
+
+    // MARK: Loop control inputs
+
+    /// Whether `token` ends decoding under the injected ``EOSPolicy``.
+    func terminatesDecoding(_ token: TokenID) -> Bool {
+        guard let eosTokenID else { return false }
+        return Int(token) == eosTokenID
+    }
+
+    /// Fully emitted tokens so far.
+    var generatedTokenCount: Int { generatedTokens.count }
+    /// Prompt plus fully emitted tokens so far.
+    var allTokensCount: Int { allTokens.count }
+    /// First-token latency captured so far (`0` before the first emission point).
+    var firstTokenLatencyMs: Double { firstTokenLatencyMsValue }
+
+    // MARK: The four concerns
+
+    /// Concern 1 — first-token latency capture.
+    ///
+    /// Idempotent: loops that must record before their EOS check call this
+    /// explicitly, and ``emit(_:at:)`` calls it again as a safety net for
+    /// closure-style loops whose only capture point is the emit itself.
+    mutating func recordFirstTokenIfFirst(at now: UInt64) {
+        guard !firstTokenRecorded else { return }
+        firstTokenLatencyMsValue = Self.milliseconds(from: now - startNanos)
+        firstTokenRecorded = true
+    }
+
+    /// Concerns 1–3 — record one fully emitted token.
+    ///
+    /// Appends to both token arrays, records the per-token latency against the
+    /// previous emission clock, updates the running rate, and fires `onStep`
+    /// with the constructed step.
+    mutating func emit(_ token: TokenID, at now: UInt64) {
+        generatedTokens.append(token)
+        allTokens.append(token)
+        let tokenLatencyMs = Self.milliseconds(from: now - lastEmissionNanos)
+        tokenLatenciesMs.append(tokenLatencyMs)
+        recordFirstTokenIfFirst(at: now)
+        let elapsedMs = Self.milliseconds(from: now - startNanos)
+        let tokensPerSecond = Self.tokensPerSecond(
+            count: generatedTokens.count,
+            elapsedMs: elapsedMs
+        )
+        onStep?(
+            GenerationStep(
+                token: token,
+                generatedTokens: generatedTokens,
+                text: decodeText(allTokens.map(Int.init)),
+                tokenLatencyMs: tokenLatencyMs,
+                elapsedMs: elapsedMs,
+                firstTokenLatencyMs: firstTokenLatencyMsValue,
+                tokensPerSecond: tokensPerSecond
+            )
+        )
+        lastEmissionNanos = now
+    }
+
+    /// Record a llama-family terminal token: it lands in the reported `tokens`
+    /// array but not in the decoded text, and fires no step callback.
+    mutating func recordTerminalToken(_ token: TokenID) {
+        generatedTokens.append(token)
+    }
+
+    /// Concern 4 — assemble the final result from accumulated state plus the
+    /// trunk-level fields only this loop knows.
+    func makeResult(
+        compileTimeMs: Double,
+        exactHeadBackend: String? = nil,
+        cachedBindingsEnabled: Bool = false,
+        committedExactTokensPerPass: Double? = nil,
+        acceptedFutureTokensPerPass: Double? = nil,
+        trunk: Trunk? = nil,
+        hopsPerToken: Int? = nil,
+        decodeProfileReport: String? = nil,
+        tokensPerSecondOverride: Double? = nil,
+        textOverride: String? = nil,
+        at now: UInt64 = DispatchTime.now().uptimeNanoseconds
+    ) -> GenerationResult {
+        GenerationResult(
+            text: textOverride ?? decodeText(allTokens.map(Int.init)),
+            tokens: generatedTokens,
+            promptTokens: promptTokens,
+            tokenLatenciesMs: tokenLatenciesMs,
+            tokensPerSecond: tokensPerSecondOverride ?? Self.tokensPerSecond(
+                count: generatedTokens.count,
+                elapsedMs: Self.milliseconds(from: now - startNanos)
+            ),
+            compileTimeMs: compileTimeMs,
+            firstTokenLatencyMs: firstTokenLatencyMsValue,
+            exactHeadBackend: exactHeadBackend ?? "unknown",
+            cachedBindingsEnabled: cachedBindingsEnabled,
+            committedExactTokensPerPass: committedExactTokensPerPass,
+            acceptedFutureTokensPerPass: acceptedFutureTokensPerPass,
+            trunk: trunk,
+            hopsPerToken: hopsPerToken,
+            decodeProfileReport: decodeProfileReport
+        )
+    }
+
+    /// Concern 2 — the one rate formula used in-loop and at result assembly.
+    static func tokensPerSecond(count: Int, elapsedMs: Double) -> Double {
+        guard count > 0 else { return 0 }
+        return Double(count) / max(elapsedMs / 1_000, 1e-9)
+    }
+
+    private static func milliseconds(from nanoseconds: UInt64) -> Double {
+        Double(nanoseconds) / 1_000_000
+    }
+}

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -1853,7 +1853,17 @@ public struct RealModelInferenceEngine: ~Copyable {
         let seam = Self.resolveDecodePlanSeam(config: config, options: decodeOptions, environment: environment)
         let plan = seam.plan
         if effectiveMaxTokens == 0 {
-            let text = tokenizer.decode(promptTokens.map(Int.init))
+            let tokenizer = self.tokenizer
+            let eosPolicy: EOSPolicy = config.architecture == .llama
+                ? .fromConfig(config.eosToken.map(Int.init))
+                : .fixed(Int(Self.gpt2EOSToken))
+            let emission = EmissionCore(
+                promptTokens: promptTokens,
+                capacity: 0,
+                eos: eosPolicy,
+                onStep: nil,
+                decodeText: { tokenizer.decode($0) }
+            )
             var trunk: Trunk?
             var hopsPerToken: Int?
             if config.architecture == .llama {
@@ -1862,16 +1872,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     ? Self.fusedHopsPerToken(nLayer: config.nLayer)
                     : nil
             }
-            return GenerationResult(
-                text: text,
-                tokens: [],
-                promptTokens: promptTokens,
-                tokensPerSecond: 0,
-                compileTimeMs: 0,
-                firstTokenLatencyMs: 0,
-                trunk: trunk,
-                hopsPerToken: hopsPerToken
-            )
+            return emission.makeResult(compileTimeMs: 0, trunk: trunk, hopsPerToken: hopsPerToken)
         }
 
         let targetTokenCount = min(config.maxSeq, promptTokens.count + effectiveMaxTokens)
@@ -2032,22 +2033,22 @@ public struct RealModelInferenceEngine: ~Copyable {
             throw RealModelInferenceError.runtimeFailure("Compiled ANE surfaces are unavailable")
         }
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
-
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fixed(Int(Self.gpt2EOSToken)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var rng = SystemRandomNumberGenerator()
         let activeBucket = compiledBucket
 
         for _ in 0..<effectiveMaxTokens {
-            let stepStart = DispatchTime.now().uptimeNanoseconds
-            let sequenceLength = allTokens.count
-            let activation = composeEmbeddingInput(tokens: allTokens, spatial: activeBucket)
+            let sequenceLength = emission.allTokensCount
+            let activation = composeEmbeddingInput(tokens: emission.allTokens, spatial: activeBucket)
             try activation.withUnsafeBufferPointer { buffer in
                 try Self.writeFP32(to: inputSurface, data: buffer)
             }
@@ -2085,51 +2086,21 @@ public struct RealModelInferenceEngine: ~Copyable {
                 using: &rng
             )
 
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: DispatchTime.now().uptimeNanoseconds - generationStart)
-                firstTokenRecorded = true
-            }
+            let emissionNow = DispatchTime.now().uptimeNanoseconds
+            emission.recordFirstTokenIfFirst(at: emissionNow)
 
-            if nextToken == Self.gpt2EOSToken {
+            if emission.terminatesDecoding(nextToken) {
                 break
             }
 
-            generatedTokens.append(nextToken)
-            allTokens.append(nextToken)
-            let elapsedMs = Self.milliseconds(from: DispatchTime.now().uptimeNanoseconds - generationStart)
-            let tokenLatencyMs = Self.milliseconds(from: DispatchTime.now().uptimeNanoseconds - stepStart)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            onStep?(
-                GenerationStep(
-                    token: nextToken,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
-            if allTokens.count >= config.maxSeq {
+            emission.emit(nextToken, at: emissionNow)
+            if emission.allTokensCount >= config.maxSeq {
                 break
             }
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
             cachedBindingsEnabled: false
         )
@@ -5335,21 +5306,21 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
-
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fixed(Int(Self.gpt2EOSToken)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var rng = SystemRandomNumberGenerator()
         var normalized = [Float](repeating: 0, count: config.dModel)
         let headSpatial = compiledHybridHeadSpatial
 
-        while generatedTokens.count < effectiveMaxTokens {
+        while emission.generatedTokenCount < effectiveMaxTokens {
             try Self.throwIfCancelled(isCancelled)
             let nextToken: TokenID
             if useANEGreedyHead {
@@ -5407,39 +5378,19 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             }
             let emissionNow = DispatchTime.now().uptimeNanoseconds
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
+            emission.recordFirstTokenIfFirst(at: emissionNow)
 
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
-
-            if nextToken == Self.gpt2EOSToken {
+            if emission.terminatesDecoding(nextToken) {
                 break
             }
 
-            generatedTokens.append(nextToken)
-            allTokens.append(nextToken)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            onStep?(
-                GenerationStep(
-                    token: nextToken,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
+            emission.emit(nextToken, at: emissionNow)
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
                 break
             }
 
-            try writeIncrementalEmbedding(token: nextToken, position: allTokens.count - 1, into: xCur)
+            try writeIncrementalEmbedding(token: nextToken, position: emission.allTokensCount - 1, into: xCur)
             do {
                 try ForwardPass.runHybridDecodeTimed(
                     xCur: xCur,
@@ -5458,26 +5409,13 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid decode failed at generated token \(generatedTokens.count - 1): \(error)"
+                    "Hybrid decode failed at generated token \(emission.generatedTokenCount - 1): \(error)"
                 )
             }
-            emissionStart = emissionNow
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
             cachedBindingsEnabled: false
         )
@@ -5514,47 +5452,23 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
-
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fixed(Int(Self.gpt2EOSToken)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
 
-        func emitToken(_ token: TokenID, at emissionNow: UInt64) {
-            generatedTokens.append(token)
-            allTokens.append(token)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            onStep?(
-                GenerationStep(
-                    token: token,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
-        }
-
-        while generatedTokens.count < effectiveMaxTokens {
+        while emission.generatedTokenCount < effectiveMaxTokens {
             let checkpoint = try cachedRuntimePair.draftRuntime.captureCheckpoint(dim: config.dModel)
             let proposedToken0: TokenID
             do {
                 proposedToken0 = try cachedRuntimePair.draftRuntime.selectGreedyToken(vocab: config.vocab)
-                try writeIncrementalEmbedding(token: proposedToken0, position: allTokens.count, into: xCur)
+                try writeIncrementalEmbedding(token: proposedToken0, position: emission.allTokensCount, into: xCur)
                 try cachedRuntimePair.draftRuntime.advanceFromBuffer(
                     xCur,
                     metalAttention: metalAttention,
@@ -5562,7 +5476,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative draft proposal-0 failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative draft proposal-0 failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
 
@@ -5571,7 +5485,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 proposedToken1 = try cachedRuntimePair.draftRuntime.selectGreedyToken(vocab: config.vocab)
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative draft proposal-1 failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative draft proposal-1 failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
 
@@ -5580,10 +5494,10 @@ public struct RealModelInferenceEngine: ~Copyable {
                 exactToken0 = try cachedRuntimePair.verifierRuntime.selectGreedyToken(vocab: config.vocab)
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative verifier token-0 failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative verifier token-0 failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
-            if exactToken0 == Self.gpt2EOSToken {
+            if emission.terminatesDecoding(exactToken0) {
                 break
             }
 
@@ -5594,7 +5508,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                         mutatedTokenCount: 1,
                         dim: config.dModel
                     )
-                    try writeIncrementalEmbedding(token: exactToken0, position: allTokens.count, into: xCur)
+                    try writeIncrementalEmbedding(token: exactToken0, position: emission.allTokensCount, into: xCur)
                     try cachedRuntimePair.draftRuntime.advanceFromBuffer(
                         xCur,
                         metalAttention: metalAttention,
@@ -5607,14 +5521,13 @@ public struct RealModelInferenceEngine: ~Copyable {
                     )
                 } catch {
                     throw RealModelInferenceError.runtimeFailure(
-                        "Hybrid speculative verifier rollback failed at generated token \(generatedTokens.count): \(error)"
+                        "Hybrid speculative verifier rollback failed at generated token \(emission.generatedTokenCount): \(error)"
                     )
                 }
 
                 let emissionNow = DispatchTime.now().uptimeNanoseconds
-                emitToken(exactToken0, at: emissionNow)
-                emissionStart = emissionNow
-                if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
+                emission.emit(exactToken0, at: emissionNow)
+                if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
                     break
                 }
                 continue
@@ -5628,15 +5541,14 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative verifier promotion failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative verifier promotion failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
 
             let emissionAfterFirst = DispatchTime.now().uptimeNanoseconds
-            emitToken(exactToken0, at: emissionAfterFirst)
-            emissionStart = emissionAfterFirst
+            emission.emit(exactToken0, at: emissionAfterFirst)
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
                 break
             }
 
@@ -5645,16 +5557,16 @@ public struct RealModelInferenceEngine: ~Copyable {
                 exactToken1 = try cachedRuntimePair.verifierRuntime.selectGreedyToken(vocab: config.vocab)
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative verifier token-1 failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative verifier token-1 failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
-            if exactToken1 == Self.gpt2EOSToken {
+            if emission.terminatesDecoding(exactToken1) {
                 break
             }
 
             do {
                 let committedSecondToken = exactToken1 == proposedToken1 ? proposedToken1 : exactToken1
-                try writeIncrementalEmbedding(token: committedSecondToken, position: allTokens.count, into: xCur)
+                try writeIncrementalEmbedding(token: committedSecondToken, position: emission.allTokensCount, into: xCur)
                 try cachedRuntimePair.draftRuntime.advanceFromBuffer(
                     xCur,
                     metalAttention: metalAttention,
@@ -5667,34 +5579,19 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Hybrid speculative commit failed at generated token \(generatedTokens.count): \(error)"
+                    "Hybrid speculative commit failed at generated token \(emission.generatedTokenCount): \(error)"
                 )
             }
 
             let emissionAfterSecond = DispatchTime.now().uptimeNanoseconds
-            emitToken(exactToken1, at: emissionAfterSecond)
-            emissionStart = emissionAfterSecond
+            emission.emit(exactToken1, at: emissionAfterSecond)
 
-            if allTokens.count >= config.maxSeq {
+            if emission.allTokensCount >= config.maxSeq {
                 break
             }
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
-            compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs
-        )
+        return emission.makeResult(compileTimeMs: compileTimeMs)
     }
 
     private mutating func cachedSpeculativeRuntimePair(
@@ -6131,23 +6028,24 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
         var decodeProfileTokens: [HybridDecodeTimingBreakdown] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
         decodeProfileTokens.reserveCapacity(effectiveMaxTokens)
         var pendingDecode = HybridDecodeTimingBreakdown()
 
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fromConfig(config.eosToken.map(Int.init)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var rng = SystemRandomNumberGenerator()
         var normalized = [Float](repeating: 0, count: config.dModel)
 
-        while generatedTokens.count < effectiveMaxTokens {
+        while emission.generatedTokenCount < effectiveMaxTokens {
             try Self.throwIfCancelled(isCancelled)
             let headStart = DispatchTime.now().uptimeNanoseconds
             normalized = xCur.withUnsafeBufferPointer {
@@ -6165,35 +6063,15 @@ public struct RealModelInferenceEngine: ~Copyable {
             )
             decodeProfileTokens.append(tokenProfile)
             let emissionNow = DispatchTime.now().uptimeNanoseconds
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
+            emission.recordFirstTokenIfFirst(at: emissionNow)
 
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
-
-            if let eosToken = config.eosToken, nextToken == eosToken {
-                generatedTokens.append(nextToken)
+            if emission.terminatesDecoding(nextToken) {
+                emission.recordTerminalToken(nextToken)
                 break
             }
-            generatedTokens.append(nextToken)
-            allTokens.append(nextToken)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            onStep?(
-                GenerationStep(
-                    token: nextToken,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
+            emission.emit(nextToken, at: emissionNow)
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
                 break
             }
 
@@ -6211,11 +6089,10 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw Self.fusedHybridFallbackError(
-                    reason: "fused N=1 decode failed at generated token \(generatedTokens.count - 1): \(error)"
+                    reason: "fused N=1 decode failed at generated token \(emission.generatedTokenCount - 1): \(error)"
                 )
             }
             pendingDecode = timings
-            emissionStart = emissionNow
         }
 
         let decodeProfileReport = decodeProfileTokens.isEmpty
@@ -6225,22 +6102,9 @@ public struct RealModelInferenceEngine: ~Copyable {
             fputs(decodeProfileReport + "\n", stderr)
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
-            cachedBindingsEnabled: false,
             trunk: .fusedHybrid,
             hopsPerToken: hopsPerToken,
             decodeProfileReport: decodeProfileReport
@@ -6571,24 +6435,25 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
         var decodeProfileTokens: [HybridDecodeTimingBreakdown] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
         decodeProfileTokens.reserveCapacity(effectiveMaxTokens)
         var pendingDecode = HybridDecodeTimingBreakdown()
 
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fromConfig(config.eosToken.map(Int.init)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var rng = SystemRandomNumberGenerator()
         var normalized = [Float](repeating: 0, count: config.dModel)
         let headSpatial = compiledHybridHeadSpatial
 
-        while generatedTokens.count < effectiveMaxTokens {
+        while emission.generatedTokenCount < effectiveMaxTokens {
             try Self.throwIfCancelled(isCancelled)
             let headStart = DispatchTime.now().uptimeNanoseconds
             let nextToken: TokenID
@@ -6657,35 +6522,15 @@ public struct RealModelInferenceEngine: ~Copyable {
             )
             decodeProfileTokens.append(tokenProfile)
             let emissionNow = DispatchTime.now().uptimeNanoseconds
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
+            emission.recordFirstTokenIfFirst(at: emissionNow)
 
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
-
-            if let eosToken = config.eosToken, nextToken == eosToken {
-                generatedTokens.append(nextToken)
+            if emission.terminatesDecoding(nextToken) {
+                emission.recordTerminalToken(nextToken)
                 break
             }
-            generatedTokens.append(nextToken)
-            allTokens.append(nextToken)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            onStep?(
-                GenerationStep(
-                    token: nextToken,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
+            emission.emit(nextToken, at: emissionNow)
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
                 break
             }
 
@@ -6715,11 +6560,10 @@ public struct RealModelInferenceEngine: ~Copyable {
                 )
             } catch {
                 throw RealModelInferenceError.runtimeFailure(
-                    "Llama hybrid decode failed at generated token \(generatedTokens.count - 1): \(error)"
+                    "Llama hybrid decode failed at generated token \(emission.generatedTokenCount - 1): \(error)"
                 )
             }
             pendingDecode = timings
-            emissionStart = emissionNow
         }
 
         let decodeProfileReport = decodeProfileTokens.isEmpty
@@ -6729,20 +6573,8 @@ public struct RealModelInferenceEngine: ~Copyable {
             fputs(decodeProfileReport + "\n", stderr)
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: greedyHeadMode == .classifierOnlyFactored && useANEGreedyHead
                 ? "ane_factored_classifier"
                 : classifierStrategy.exactHeadBackendLabel,
@@ -6812,80 +6644,36 @@ public struct RealModelInferenceEngine: ~Copyable {
         try fullRuntime.prefill(promptTokens: promptTokens)
         try draftRuntime.prefill(promptTokens: promptTokens)
 
-        var allTokens = promptTokens
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
-
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fromConfig(config.eosToken.map(Int.init)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var committedExactTokensTotal = 0
         var acceptedFutureTokensTotal = 0
         var speculativePassCount = 0
 
-        func emit(_ token: TokenID, at emissionNow: UInt64) {
-            generatedTokens.append(token)
-            allTokens.append(token)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            onStep?(
-                GenerationStep(
-                    token: token,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
-            emissionStart = emissionNow
-        }
-
         let firstToken = fullRuntime.selectGreedyToken()
-        if let eosToken = config.eosToken, firstToken == eosToken {
-            generatedTokens.append(firstToken)
-            return GenerationResult(
-                text: tokenizer.decode((promptTokens + generatedTokens).map(Int.init)),
-                tokens: generatedTokens,
-                promptTokens: promptTokens,
-                tokenLatenciesMs: tokenLatenciesMs,
-                tokensPerSecond: 0,
+        if emission.terminatesDecoding(firstToken) {
+            emission.recordTerminalToken(firstToken)
+            return emission.makeResult(
                 compileTimeMs: compileTimeMs,
-                firstTokenLatencyMs: 0,
                 exactHeadBackend: "cpu_exact_two_token_draft",
-                cachedBindingsEnabled: false,
-                committedExactTokensPerPass: nil,
-                acceptedFutureTokensPerPass: nil,
-                trunk: .exactCPU
+                trunk: .exactCPU,
+                textOverride: tokenizer.decode((promptTokens + [firstToken]).map(Int.init))
             )
         }
         let firstEmission = DispatchTime.now().uptimeNanoseconds
-        emit(firstToken, at: firstEmission)
-        if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq {
-            let totalMs = Self.milliseconds(from: DispatchTime.now().uptimeNanoseconds - generationStart)
-            let tps = generatedTokens.isEmpty ? 0 : Double(generatedTokens.count) / max(totalMs / 1_000, 1e-9)
-            return GenerationResult(
-                text: tokenizer.decode(allTokens.map(Int.init)),
-                tokens: generatedTokens,
-                promptTokens: promptTokens,
-                tokenLatenciesMs: tokenLatenciesMs,
-                tokensPerSecond: tps,
+        emission.emit(firstToken, at: firstEmission)
+        if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq {
+            return emission.makeResult(
                 compileTimeMs: compileTimeMs,
-                firstTokenLatencyMs: firstTokenLatencyMs,
                 exactHeadBackend: "cpu_exact_two_token_draft",
-                cachedBindingsEnabled: false,
-                committedExactTokensPerPass: nil,
-                acceptedFutureTokensPerPass: nil,
                 trunk: .exactCPU
             )
         }
@@ -6893,9 +6681,12 @@ public struct RealModelInferenceEngine: ~Copyable {
         try fullRuntime.advance(token: firstToken)
         try draftRuntime.advance(token: firstToken)
 
-        while generatedTokens.count < effectiveMaxTokens, allTokens.count < config.maxSeq {
+        while emission.generatedTokenCount < effectiveMaxTokens, emission.allTokensCount < config.maxSeq {
             speculativePassCount += 1
-            let remainingTokenBudget = min(effectiveMaxTokens - generatedTokens.count, config.maxSeq - allTokens.count)
+            let remainingTokenBudget = min(
+                effectiveMaxTokens - emission.generatedTokenCount,
+                config.maxSeq - emission.allTokensCount
+            )
             let draftCheckpoint = draftRuntime.captureCheckpoint()
             let proposedToken0 = draftRuntime.selectGreedyToken()
             try draftRuntime.advance(token: proposedToken0)
@@ -6911,9 +6702,9 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
 
             let firstRoundEmission = DispatchTime.now().uptimeNanoseconds
-            emit(exactToken0, at: firstRoundEmission)
+            emission.emit(exactToken0, at: firstRoundEmission)
             committedInPass += 1
-            if let eosToken = config.eosToken, exactToken0 == eosToken {
+            if emission.terminatesDecoding(exactToken0) {
                 committedExactTokensTotal += committedInPass
                 acceptedFutureTokensTotal += acceptedInPass
                 break
@@ -6923,7 +6714,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 try draftRuntime.advance(token: exactToken0)
             }
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= config.maxSeq || remainingTokenBudget <= 1 {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= config.maxSeq || remainingTokenBudget <= 1 {
                 committedExactTokensTotal += committedInPass
                 acceptedFutureTokensTotal += acceptedInPass
                 continue
@@ -6935,9 +6726,9 @@ public struct RealModelInferenceEngine: ~Copyable {
                 acceptedInPass += 1
             }
             let secondRoundEmission = DispatchTime.now().uptimeNanoseconds
-            emit(exactToken1, at: secondRoundEmission)
+            emission.emit(exactToken1, at: secondRoundEmission)
             committedInPass += 1
-            if let eosToken = config.eosToken, exactToken1 == eosToken {
+            if emission.terminatesDecoding(exactToken1) {
                 committedExactTokensTotal += committedInPass
                 acceptedFutureTokensTotal += acceptedInPass
                 break
@@ -6949,11 +6740,6 @@ public struct RealModelInferenceEngine: ~Copyable {
             acceptedFutureTokensTotal += acceptedInPass
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
         let committedExactTokensPerPass = speculativePassCount == 0
             ? nil
             : Double(committedExactTokensTotal) / Double(speculativePassCount)
@@ -6961,16 +6747,9 @@ public struct RealModelInferenceEngine: ~Copyable {
             ? nil
             : Double(acceptedFutureTokensTotal) / Double(speculativePassCount)
 
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: "cpu_exact_two_token_draft",
-            cachedBindingsEnabled: false,
             committedExactTokensPerPass: committedExactTokensPerPass,
             acceptedFutureTokensPerPass: acceptedFutureTokensPerPass,
             trunk: .exactCPU
@@ -7029,23 +6808,24 @@ public struct RealModelInferenceEngine: ~Copyable {
             return hidden
         }
 
-        var allTokens = promptTokens
         var lastHidden = [Float](repeating: 0, count: config.dModel)
         for (position, token) in promptTokens.enumerated() {
             lastHidden = try forwardToken(token, position: position)
         }
 
         let generationStart = DispatchTime.now().uptimeNanoseconds
-        var emissionStart = generationStart
-        var firstTokenLatencyMs = 0.0
-        var firstTokenRecorded = false
-        var generatedTokens: [TokenID] = []
-        var tokenLatenciesMs: [Double] = []
-        generatedTokens.reserveCapacity(effectiveMaxTokens)
-        tokenLatenciesMs.reserveCapacity(effectiveMaxTokens)
+        let tokenizer = self.tokenizer
+        var emission = EmissionCore(
+            promptTokens: promptTokens,
+            capacity: effectiveMaxTokens,
+            eos: .fromConfig(config.eosToken.map(Int.init)),
+            onStep: onStep,
+            decodeText: { tokenizer.decode($0) },
+            startNanos: generationStart
+        )
         var rng = SystemRandomNumberGenerator()
 
-        while generatedTokens.count < effectiveMaxTokens {
+        while emission.generatedTokenCount < effectiveMaxTokens {
             try Self.throwIfCancelled(isCancelled)
             let normalized = Self.rmsNorm(lastHidden, weight: finalNormGamma, eps: Float(config.normEps))
             let nextToken: TokenID
@@ -7061,56 +6841,24 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
 
             let emissionNow = DispatchTime.now().uptimeNanoseconds
-            let tokenLatencyMs = Self.milliseconds(from: emissionNow - emissionStart)
-            if !firstTokenRecorded {
-                firstTokenLatencyMs = Self.milliseconds(from: emissionNow - generationStart)
-                firstTokenRecorded = true
-            }
+            emission.recordFirstTokenIfFirst(at: emissionNow)
 
-            if let eosToken = config.eosToken, nextToken == eosToken {
-                generatedTokens.append(nextToken)
+            if emission.terminatesDecoding(nextToken) {
+                emission.recordTerminalToken(nextToken)
                 break
             }
 
-            generatedTokens.append(nextToken)
-            allTokens.append(nextToken)
-            let elapsedMs = Self.milliseconds(from: emissionNow - generationStart)
-            let tokensPerSecond = Double(generatedTokens.count) / max(elapsedMs / 1_000, 1e-9)
-            tokenLatenciesMs.append(tokenLatencyMs)
-            onStep?(
-                GenerationStep(
-                    token: nextToken,
-                    generatedTokens: generatedTokens,
-                    text: tokenizer.decode(allTokens.map(Int.init)),
-                    tokenLatencyMs: tokenLatencyMs,
-                    elapsedMs: elapsedMs,
-                    firstTokenLatencyMs: firstTokenLatencyMs,
-                    tokensPerSecond: tokensPerSecond
-                )
-            )
+            emission.emit(nextToken, at: emissionNow)
 
-            if generatedTokens.count >= effectiveMaxTokens || allTokens.count >= maxSeq {
+            if emission.generatedTokenCount >= effectiveMaxTokens || emission.allTokensCount >= maxSeq {
                 break
             }
 
-            lastHidden = try forwardToken(nextToken, position: allTokens.count - 1)
-            emissionStart = emissionNow
+            lastHidden = try forwardToken(nextToken, position: emission.allTokensCount - 1)
         }
 
-        let generationEnd = DispatchTime.now().uptimeNanoseconds
-        let generationTimeMs = Self.milliseconds(from: generationEnd - generationStart)
-        let tokensPerSecond = generatedTokens.isEmpty
-            ? 0
-            : Double(generatedTokens.count) / max(generationTimeMs / 1_000, 1e-9)
-
-        return GenerationResult(
-            text: tokenizer.decode(allTokens.map(Int.init)),
-            tokens: generatedTokens,
-            promptTokens: promptTokens,
-            tokenLatenciesMs: tokenLatenciesMs,
-            tokensPerSecond: tokensPerSecond,
+        return emission.makeResult(
             compileTimeMs: compileTimeMs,
-            firstTokenLatencyMs: firstTokenLatencyMs,
             exactHeadBackend: classifierStrategy.exactHeadBackendLabel,
             trunk: .exactCPU
         )

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -6665,6 +6665,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 compileTimeMs: compileTimeMs,
                 exactHeadBackend: "cpu_exact_two_token_draft",
                 trunk: .exactCPU,
+                tokensPerSecondOverride: 0,
                 textOverride: tokenizer.decode((promptTokens + [firstToken]).map(Int.init))
             )
         }

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -218,9 +218,38 @@ public enum RealModelInferenceError: Error, Sendable, Equatable, LocalizedError 
     }
 }
 
+extension GenerationResult {
+    /// Copy of the result with the decode profile report dropped, used by the
+    /// token-suite helper so a profile string cannot outlive its ANE surfaces.
+    func strippingDecodeProfileReport() -> GenerationResult {
+        GenerationResult(
+            text: text,
+            tokens: tokens,
+            promptTokens: promptTokens,
+            tokenLatenciesMs: tokenLatenciesMs,
+            tokensPerSecond: tokensPerSecond,
+            compileTimeMs: compileTimeMs,
+            firstTokenLatencyMs: firstTokenLatencyMs,
+            exactHeadBackend: exactHeadBackend,
+            cachedBindingsEnabled: cachedBindingsEnabled,
+            committedExactTokensPerPass: committedExactTokensPerPass,
+            acceptedFutureTokensPerPass: acceptedFutureTokensPerPass,
+            trunk: trunk,
+            hopsPerToken: hopsPerToken,
+            decodeProfileReport: nil
+        )
+    }
+}
+
 public struct RealModelInferenceEngine: ~Copyable {
     private static let minimumANEIOSurfaceBytes = 49_152
     private static let classifierArgmaxBlockSize = 4_000
+
+    /// Single process-environment seam for this file: every read flows through
+    /// here so global-state access stays auditable in one place.
+    static var processEnvironment: [String: String] {
+        ProcessInfo.processInfo.environment
+    }
 
     public struct GPT2AttentionCompileProbeResult: Sendable, Equatable {
         public let spatial: Int
@@ -463,7 +492,7 @@ public struct RealModelInferenceEngine: ~Copyable {
     }
 
     static func shouldRoundCPUExactDecodeIntermediatesToFP16(
-        env: [String: String] = ProcessInfo.processInfo.environment
+        env: [String: String] = Self.processEnvironment
     ) -> Bool {
         guard let rawValue = env["ESPRESSO_DEBUG_CPU_EXACT_DECODE_KEEP_FP32_INTERMEDIATES"] else {
             return false
@@ -480,26 +509,14 @@ public struct RealModelInferenceEngine: ~Copyable {
         config: MultiModelConfig,
         environment: [String: String]
     ) -> Bool {
-        if environment["ESPRESSO_FORCE_HYBRID_DECODE"] == "1" {
-            return false
-        }
-        if environment["ESPRESSO_USE_CPU_EXACT_DECODE"] == "1" {
-            return true
-        }
-        guard config.architecture == .llama else {
-            return false
-        }
-        // An artifact that states where it decodes is trusted over the name heuristic below.
-        if let declared = config.preferredDecodePath {
-            return declared == .exactCPU
-        }
-        // Legacy routing: early Qwen artifacts predate a working ANE path at these widths
-        // and are kept on the CPU oracle so old bundles do not change behaviour.
-        return ModelFamily.isQwenVariant(config)
+        DecodePathPolicy.prefersCPUExactDecode(
+            config: config,
+            options: DecodePathPolicy.optionsFromEnvironment(environment)
+        )
     }
 
     static func isHybridFallbackDisabled(environment: [String: String]) -> Bool {
-        environment["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK"] == "1"
+        DecodePathPolicy.optionsFromEnvironment(environment).disableHybridFallback
     }
 
     /// Resolves the llama serving ``Trunk``, refusing to leave the ANE silently.
@@ -511,30 +528,15 @@ public struct RealModelInferenceEngine: ~Copyable {
         config: MultiModelConfig,
         environment: [String: String]
     ) throws -> Trunk {
-        let trunk = selectTrunk(config: config, environment: environment)
-        guard trunk == .exactCPU, isHybridFallbackDisabled(environment: environment) else {
-            return trunk
-        }
-        let reason: String
-        if environment["ESPRESSO_USE_CPU_EXACT_DECODE"] == "1" {
-            reason = "ESPRESSO_USE_CPU_EXACT_DECODE=1 explicitly requests the pure-CPU decode path"
-        } else if config.preferredDecodePath == .exactCPU {
-            reason = "the artifact declares preferredDecodePath=exact_cpu in metadata.json"
-        } else {
-            reason = """
-                model name "\(config.name)" matches the legacy Qwen CPU-exact routing policy \
-                and metadata.json does not declare preferredDecodePath; set \
-                preferredDecodePath=hybrid or ESPRESSO_FORCE_HYBRID_DECODE=1 to decode on the ANE
-                """
-        }
-        throw RealModelInferenceError.hybridFallbackDisabled(
-            stage: "llama trunk selection",
-            reason: reason
+        try DecodePathPolicy.resolvedTrunk(
+            config: config,
+            fusedHybridPreferred: prefersFusedHybridDecode(config: config, environment: environment),
+            options: DecodePathPolicy.optionsFromEnvironment(environment)
         )
     }
 
     static func milDeploymentTarget(
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) -> String {
         let rawValue = environment["ESPRESSO_MIL_DEPLOYMENT_TARGET"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -542,7 +544,7 @@ public struct RealModelInferenceEngine: ~Copyable {
     }
 
     static func gpt2NormKind(
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) -> GPT2NormKind {
         if environment["ESPRESSO_GPT2_USE_RMS_NORM"] == "1" {
             return .rmsNorm
@@ -561,7 +563,7 @@ public struct RealModelInferenceEngine: ~Copyable {
     static func hybridGreedyHeadMode(
         config: MultiModelConfig,
         hasFactoredOutputHead: Bool,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) -> HybridGreedyHeadMode {
         guard config.architecture == .llama else {
             return .normThenClassifier
@@ -580,22 +582,11 @@ public struct RealModelInferenceEngine: ~Copyable {
         config: MultiModelConfig,
         environment: [String: String]
     ) -> Trunk {
-        if prefersCPUExactDecode(config: config, environment: environment) {
-            return .exactCPU
-        }
-        if prefersFusedHybridDecode(config: config, environment: environment) {
-            return .fusedHybrid
-        }
-        return .splitHybrid
-    }
-
-    static func hopsPerToken(for trunk: Trunk, nLayer: Int) -> Int? {
-        switch trunk {
-        case .fusedHybrid:
-            return fusedHopsPerToken(nLayer: nLayer)
-        case .splitHybrid, .exactCPU:
-            return nil
-        }
+        DecodePathPolicy.resolve(
+            config: config,
+            fusedHybridPreferred: prefersFusedHybridDecode(config: config, environment: environment),
+            options: DecodePathPolicy.optionsFromEnvironment(environment)
+        ).trunk
     }
 
     struct TopLevelWeightPaths: Sendable, Equatable {
@@ -1264,7 +1255,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             if layers.count > 1,
                RealModelInferenceEngine.usesHybridLayerInputRebinding(
                    architecture: config.architecture,
-                   environment: ProcessInfo.processInfo.environment
+                   environment: RealModelInferenceEngine.processEnvironment
                ) {
                 for localLayerIndex in 1..<layers.count {
                     do {
@@ -1335,7 +1326,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             self.zeroSlice = zeroSlice
             self.preferCPUDecodeAttention = RealModelInferenceEngine.prefersCPUDecodeAttention(
                 config: config,
-                environment: ProcessInfo.processInfo.environment
+                environment: RealModelInferenceEngine.processEnvironment
             )
             self.decodeState = decodeState
         }
@@ -1512,7 +1503,7 @@ public struct RealModelInferenceEngine: ~Copyable {
     }
 
     private func hybridGreedyHeadMode(
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) -> HybridGreedyHeadMode {
         let hasFactoredOutputHead: Bool
         if config.architecture == .llama {
@@ -1565,7 +1556,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         weightDirURL: URL,
         tokenizer: LoadedTokenizer,
         assets: TopLevelAssets,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) {
         let lmHead: [Float]
         let hasExactFloat32LMHead: Bool
@@ -1649,10 +1640,177 @@ public struct RealModelInferenceEngine: ~Copyable {
         )
     }
 
+    /// The decode-path bootstrap seam: resolves the serving plan from explicit options
+    /// when provided, otherwise from the bounded decode-path environment variables.
+    private static func resolveDecodePlanSeam(
+        config: MultiModelConfig,
+        options: DecodePathOptions?,
+        environment: [String: String] = Self.processEnvironment
+    ) -> (plan: ResolvedDecodePlan, options: DecodePathOptions, fusedHybridPreferred: Bool) {
+        let decodeOptions = options ?? DecodePathPolicy.optionsFromEnvironment(environment)
+        let fusedHybridPreferred = Self.prefersFusedHybridDecode(config: config, environment: environment)
+        let plan = DecodePathPolicy.resolve(
+            config: config,
+            fusedHybridPreferred: fusedHybridPreferred,
+            options: decodeOptions
+        )
+        return (plan, decodeOptions, fusedHybridPreferred)
+    }
+
+    /// Compile-and-prepare state for one llama trunk's decode programs.
+    private struct LlamaTrunkPreparation {
+        let compileTimeMs: Double
+        let metalAttention: MetalAttentionKernel?
+    }
+
+    /// One unit of llama serving work routed through the single ``Trunk`` dispatch point.
+    private struct LlamaDecodeRequest {
+        let trunk: Trunk
+        let plan: ResolvedDecodePlan
+        let bucket: Int
+        /// Names the caller in attention-unavailability errors ("llama" vs "llama testing helper").
+        let sessionKind: String
+        let promptTokens: [TokenID]
+        let effectiveMaxTokens: Int
+        let temperature: Float
+        var topP: Float = 1.0
+        var compileTimeMs: Double = 0
+        /// Precomputed `prepareLlamaTrunkDecode` output; when nil the dispatcher prepares.
+        var preparation: LlamaTrunkPreparation?
+        /// Explicit decode-session context length; per-trunk defaults apply when nil.
+        var maxSeq: Int? = nil
+        var onStep: ((GenerationStep) -> Void)? = nil
+        var isCancelled: (() -> Bool)? = nil
+        var dropsDecodeProfileReport = false
+    }
+
+    /// Compiles decode programs for a selected llama trunk without decoding anything.
+    ///
+    /// Shared by chat precompile and the token-suite warmup; the fused error-wrapping and
+    /// Metal-attention guards live here so every entry point behaves identically.
+    private mutating func prepareLlamaTrunkDecode(
+        _ trunk: Trunk,
+        bucket: Int,
+        sessionKind: String
+    ) throws -> LlamaTrunkPreparation {
+        if trunk == .fusedHybrid {
+            let compileStart = DispatchTime.now().uptimeNanoseconds
+            let compileDidRun: Bool
+            do {
+                compileDidRun = try ensureFusedHybridCompiled(bucket: bucket)
+            } catch let error as RealModelInferenceError {
+                if case .hybridFallbackDisabled = error { throw error }
+                throw Self.fusedHybridFallbackError(
+                    reason: error.errorDescription ?? "\(error)"
+                )
+            } catch {
+                throw Self.fusedHybridFallbackError(reason: "\(error)")
+            }
+            let compileEnd = DispatchTime.now().uptimeNanoseconds
+            return LlamaTrunkPreparation(
+                compileTimeMs: compileDidRun ? Self.milliseconds(from: compileEnd - compileStart) : 0,
+                metalAttention: nil
+            )
+        }
+        if trunk == .splitHybrid {
+            let compileStart = DispatchTime.now().uptimeNanoseconds
+            let compileDidRun = try ensureHybridCompiledLlama(bucket: bucket)
+            guard let metalAttention = hybridMetalAttention else {
+                throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention unavailable for \(sessionKind)")
+            }
+            let compileEnd = DispatchTime.now().uptimeNanoseconds
+            return LlamaTrunkPreparation(
+                compileTimeMs: compileDidRun ? Self.milliseconds(from: compileEnd - compileStart) : 0,
+                metalAttention: metalAttention
+            )
+        }
+        return LlamaTrunkPreparation(compileTimeMs: 0, metalAttention: nil)
+    }
+
+    /// THE single ``Trunk`` dispatch point for llama serving sessions (REQ-004): every
+    /// decode path funnels its per-trunk preparation and session work through this switch.
+    private mutating func dispatchLlamaTrunkDecode(
+        _ request: LlamaDecodeRequest
+    ) throws -> GenerationResult {
+        switch request.trunk {
+        case .exactCPU:
+            return try generateIncrementalExactCPULlama(
+                promptTokens: request.promptTokens,
+                effectiveMaxTokens: request.effectiveMaxTokens,
+                temperature: request.temperature,
+                topP: request.topP,
+                compileTimeMs: request.compileTimeMs,
+                maxSeq: request.maxSeq ?? request.bucket,
+                onStep: request.onStep,
+                isCancelled: request.isCancelled
+            )
+        case .fusedHybrid:
+            let prepared: LlamaTrunkPreparation
+            let sessionCompileTimeMs: Double
+            if let provided = request.preparation {
+                prepared = provided
+                sessionCompileTimeMs = request.compileTimeMs
+            } else {
+                prepared = try prepareLlamaTrunkDecode(
+                    .fusedHybrid,
+                    bucket: request.bucket,
+                    sessionKind: request.sessionKind
+                )
+                sessionCompileTimeMs = prepared.compileTimeMs
+            }
+            let result = try generateIncrementalFusedHybridLlama(
+                promptTokens: request.promptTokens,
+                effectiveMaxTokens: request.effectiveMaxTokens,
+                temperature: request.temperature,
+                topP: request.topP,
+                compileTimeMs: sessionCompileTimeMs,
+                maxSeq: request.maxSeq ?? max(request.bucket, compiledFusedHybridBucket),
+                onStep: request.onStep,
+                isCancelled: request.isCancelled
+            )
+            if request.dropsDecodeProfileReport {
+                return result.strippingDecodeProfileReport()
+            }
+            return result
+        case .splitHybrid:
+            let prepared: LlamaTrunkPreparation
+            let sessionCompileTimeMs: Double
+            if let provided = request.preparation {
+                prepared = provided
+                sessionCompileTimeMs = request.compileTimeMs
+            } else {
+                prepared = try prepareLlamaTrunkDecode(
+                    .splitHybrid,
+                    bucket: request.bucket,
+                    sessionKind: request.sessionKind
+                )
+                sessionCompileTimeMs = prepared.compileTimeMs
+            }
+            guard let metalAttention = prepared.metalAttention else {
+                throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention unavailable for \(request.sessionKind)")
+            }
+            return try generateIncrementalHybridLlama(
+                promptTokens: request.promptTokens,
+                effectiveMaxTokens: request.effectiveMaxTokens,
+                temperature: request.temperature,
+                topP: request.topP,
+                compileTimeMs: sessionCompileTimeMs,
+                maxSeq: request.maxSeq ?? max(request.bucket, compiledHybridBucket),
+                metalAttention: metalAttention,
+                plan: request.plan,
+                onStep: request.onStep,
+                isCancelled: request.isCancelled
+            )
+        }
+    }
+
     /// Compile hybrid decode kernels once for a context that covers later turns.
     /// Chat re-prefills growing history; compiling per-turn at a larger bucket
     /// exhausts the per-process ANE compile budget.
-    public mutating func precompileHybridDecode(covering tokenCount: Int? = nil) throws {
+    public mutating func precompileHybridDecode(
+        covering tokenCount: Int? = nil,
+        options decodeOptions: DecodePathOptions? = nil
+    ) throws {
         let target = min(max(tokenCount ?? config.maxSeq, 1), config.maxSeq)
         let bucket = try Self.compileBucket(
             for: target,
@@ -1661,26 +1819,8 @@ public struct RealModelInferenceEngine: ~Copyable {
         )
         switch config.architecture {
         case .llama:
-            switch Self.selectTrunk(
-                config: config,
-                environment: ProcessInfo.processInfo.environment
-            ) {
-            case .fusedHybrid:
-                do {
-                    _ = try ensureFusedHybridCompiled(bucket: bucket)
-                } catch let error as RealModelInferenceError {
-                    if case .hybridFallbackDisabled = error { throw error }
-                    throw Self.fusedHybridFallbackError(
-                        reason: error.errorDescription ?? "\(error)"
-                    )
-                } catch {
-                    throw Self.fusedHybridFallbackError(reason: "\(error)")
-                }
-            case .splitHybrid:
-                _ = try ensureHybridCompiledLlama(bucket: bucket)
-            case .exactCPU:
-                break
-            }
+            let seam = Self.resolveDecodePlanSeam(config: config, options: decodeOptions)
+            _ = try prepareLlamaTrunkDecode(seam.plan.trunk, bucket: bucket, sessionKind: "llama")
         case .gpt2:
             _ = try ensureHybridCompiled(bucket: bucket)
         }
@@ -1692,7 +1832,8 @@ public struct RealModelInferenceEngine: ~Copyable {
         temperature: Float = 0.0,
         topP: Float = 1.0,
         onStep: ((GenerationStep) -> Void)? = nil,
-        isCancelled: (() -> Bool)? = nil
+        isCancelled: (() -> Bool)? = nil,
+        options decodeOptions: DecodePathOptions? = nil
     ) throws -> GenerationResult {
         guard maxTokens >= 0 else {
             throw RealModelInferenceError.invalidGenerationParameters("maxTokens must be >= 0")
@@ -1714,18 +1855,18 @@ public struct RealModelInferenceEngine: ~Copyable {
 
         let remainingContext = config.maxSeq - promptTokens.count
         let effectiveMaxTokens = min(maxTokens, max(remainingContext, 0))
-        let environment = ProcessInfo.processInfo.environment
+        let environment = Self.processEnvironment
+        let seam = Self.resolveDecodePlanSeam(config: config, options: decodeOptions, environment: environment)
+        let plan = seam.plan
         if effectiveMaxTokens == 0 {
             let text = tokenizer.decode(promptTokens.map(Int.init))
-            let trunk: Trunk?
-            let hopsPerToken: Int?
+            var trunk: Trunk?
+            var hopsPerToken: Int?
             if config.architecture == .llama {
-                let selected = Self.selectTrunk(config: config, environment: environment)
-                trunk = selected
-                hopsPerToken = Self.hopsPerToken(for: selected, nLayer: config.nLayer)
-            } else {
-                trunk = nil
-                hopsPerToken = nil
+                trunk = plan.trunk
+                hopsPerToken = plan.trunk == .fusedHybrid
+                    ? Self.fusedHopsPerToken(nLayer: config.nLayer)
+                    : nil
             }
             return GenerationResult(
                 text: text,
@@ -1761,66 +1902,23 @@ public struct RealModelInferenceEngine: ~Copyable {
                     onStep: onStep
                 )
             }
-            switch try Self.resolvedTrunk(
+            let trunk = try DecodePathPolicy.resolvedTrunk(
                 config: config,
-                environment: environment
-            ) {
-            case .exactCPU:
-                return try generateIncrementalExactCPULlama(
-                    promptTokens: promptTokens,
-                    effectiveMaxTokens: effectiveMaxTokens,
-                    temperature: temperature,
-                    topP: topP,
-                    compileTimeMs: 0,
-                    maxSeq: bucket,
-                    onStep: onStep,
-                    isCancelled: isCancelled
-                )
-            case .fusedHybrid:
-                let compileStart = DispatchTime.now().uptimeNanoseconds
-                let compileDidRun: Bool
-                do {
-                    compileDidRun = try ensureFusedHybridCompiled(bucket: bucket)
-                } catch let error as RealModelInferenceError {
-                    if case .hybridFallbackDisabled = error { throw error }
-                    throw Self.fusedHybridFallbackError(
-                        reason: error.errorDescription ?? "\(error)"
-                    )
-                } catch {
-                    throw Self.fusedHybridFallbackError(reason: "\(error)")
-                }
-                let compileEnd = DispatchTime.now().uptimeNanoseconds
-                let compileTimeMs = compileDidRun ? Self.milliseconds(from: compileEnd - compileStart) : 0
-                return try generateIncrementalFusedHybridLlama(
-                    promptTokens: promptTokens,
-                    effectiveMaxTokens: effectiveMaxTokens,
-                    temperature: temperature,
-                    topP: topP,
-                    compileTimeMs: compileTimeMs,
-                    maxSeq: max(bucket, compiledFusedHybridBucket),
-                    onStep: onStep,
-                    isCancelled: isCancelled
-                )
-            case .splitHybrid:
-                let compileStart = DispatchTime.now().uptimeNanoseconds
-                let compileDidRun = try ensureHybridCompiledLlama(bucket: bucket)
-                guard let metalAttention = hybridMetalAttention else {
-                    throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention unavailable for llama")
-                }
-                let compileEnd = DispatchTime.now().uptimeNanoseconds
-                let compileTimeMs = compileDidRun ? Self.milliseconds(from: compileEnd - compileStart) : 0
-                return try generateIncrementalHybridLlama(
-                    promptTokens: promptTokens,
-                    effectiveMaxTokens: effectiveMaxTokens,
-                    temperature: temperature,
-                    topP: topP,
-                    compileTimeMs: compileTimeMs,
-                    maxSeq: max(bucket, compiledHybridBucket),
-                    metalAttention: metalAttention,
-                    onStep: onStep,
-                    isCancelled: isCancelled
-                )
-            }
+                fusedHybridPreferred: seam.fusedHybridPreferred,
+                options: seam.options
+            )
+            return try dispatchLlamaTrunkDecode(LlamaDecodeRequest(
+                trunk: trunk,
+                plan: plan,
+                bucket: bucket,
+                sessionKind: "llama",
+                promptTokens: promptTokens,
+                effectiveMaxTokens: effectiveMaxTokens,
+                temperature: temperature,
+                topP: topP,
+                onStep: onStep,
+                isCancelled: isCancelled
+            ))
         }
 
         let compileStart = DispatchTime.now().uptimeNanoseconds
@@ -1835,7 +1933,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 compiledHybridSurfaceHandles.count == config.nLayer &&
                 compiledHybridHead.count == 1 &&
                 hybridMetalAttention != nil
-            if !useHybridFastPath, Self.isHybridFallbackDisabled(environment: environment) {
+            if !useHybridFastPath, !plan.allowsHybridFallback {
                 throw RealModelInferenceError.hybridFallbackDisabled(
                     stage: "hybrid decode compile",
                     reason: """
@@ -1851,7 +1949,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             if case .hybridFallbackDisabled = error {
                 throw error
             }
-            if Self.isHybridFallbackDisabled(environment: environment) {
+            if !plan.allowsHybridFallback {
                 throw RealModelInferenceError.hybridFallbackDisabled(
                     stage: "hybrid decode compile",
                     reason: "\(error.errorDescription ?? "\(error)")"
@@ -1859,7 +1957,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
             useHybridFastPath = false
         } catch {
-            if Self.isHybridFallbackDisabled(environment: environment) {
+            if !plan.allowsHybridFallback {
                 throw RealModelInferenceError.hybridFallbackDisabled(
                     stage: "hybrid decode compile",
                     reason: "\(error)"
@@ -1891,7 +1989,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                         onStep: onStep
                     )
                 } catch {
-                    if ProcessInfo.processInfo.environment["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK"] == "1" {
+                    if !plan.allowsHybridFallback {
                         throw RealModelInferenceError.runtimeFailure("Hybrid speculative fast path failed: \(error)")
                     }
                     fputs(
@@ -1925,7 +2023,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     isCancelled: isCancelled
                 )
             } catch {
-                if ProcessInfo.processInfo.environment["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK"] == "1" {
+                if !plan.allowsHybridFallback {
                     throw RealModelInferenceError.runtimeFailure("Hybrid fast path failed: \(error)")
                 }
                 useHybridFastPath = false
@@ -2070,7 +2168,8 @@ public struct RealModelInferenceEngine: ~Copyable {
         config: MultiModelConfig,
         weightDir: String,
         promptTokenSuite: [[TokenID]],
-        maxTokens: Int
+        maxTokens: Int,
+        options decodeOptions: DecodePathOptions? = nil
     ) throws -> [GenerationResult] {
         guard !promptTokenSuite.isEmpty else {
             throw RealModelInferenceError.invalidGenerationParameters("Testing prompt suite must not be empty")
@@ -2155,38 +2254,23 @@ public struct RealModelInferenceEngine: ~Copyable {
             maxSeq: config.maxSeq
         )
 
-        let environment = ProcessInfo.processInfo.environment
-        let trunk = try resolvedTrunk(
+        let seam = Self.resolveDecodePlanSeam(config: config, options: decodeOptions)
+        let plan = seam.plan
+        let trunk = try DecodePathPolicy.resolvedTrunk(
             config: config,
-            environment: environment
+            fusedHybridPreferred: seam.fusedHybridPreferred,
+            options: seam.options
         )
         var compileTimeMs = 0.0
-        var metalAttention: MetalAttentionKernel?
-        switch trunk {
-        case .fusedHybrid:
-            let compileStart = DispatchTime.now().uptimeNanoseconds
-            let compileDidRun: Bool
-            do {
-                compileDidRun = try engine.ensureFusedHybridCompiled(bucket: bucket)
-            } catch let error as RealModelInferenceError {
-                if case .hybridFallbackDisabled = error { throw error }
-                throw fusedHybridFallbackError(reason: error.errorDescription ?? "\(error)")
-            } catch {
-                throw fusedHybridFallbackError(reason: "\(error)")
-            }
-            let compileEnd = DispatchTime.now().uptimeNanoseconds
-            compileTimeMs = compileDidRun ? milliseconds(from: compileEnd - compileStart) : 0
-        case .splitHybrid:
-            let compileStart = DispatchTime.now().uptimeNanoseconds
-            let compileDidRun = try engine.ensureHybridCompiledLlama(bucket: bucket)
-            guard let attention = engine.hybridMetalAttention else {
-                throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention unavailable for llama testing helper")
-            }
-            metalAttention = attention
-            let compileEnd = DispatchTime.now().uptimeNanoseconds
-            compileTimeMs = compileDidRun ? milliseconds(from: compileEnd - compileStart) : 0
-        case .exactCPU:
-            break
+        var preparation: LlamaTrunkPreparation?
+        if trunk != .exactCPU {
+            // Compile once for the longest prompt so no prompt triggers a second compile.
+            preparation = try engine.prepareLlamaTrunkDecode(
+                trunk,
+                bucket: bucket,
+                sessionKind: "llama testing helper"
+            )
+            compileTimeMs = preparation?.compileTimeMs ?? 0
         }
 
         var results: [GenerationResult] = []
@@ -2198,63 +2282,23 @@ public struct RealModelInferenceEngine: ~Copyable {
                     "Prompt of \(prompt.count) tokens leaves no room to generate within context \(config.maxSeq)"
                 )
             }
-            switch trunk {
-            case .exactCPU:
-                results.append(
-                    try engine.generateIncrementalExactCPULlama(
-                        promptTokens: prompt,
-                        effectiveMaxTokens: effectiveMaxTokens,
-                        temperature: 0,
-                        compileTimeMs: 0,
-                        maxSeq: bucket,
-                        onStep: nil
-                    )
-                )
-            case .fusedHybrid:
-                let result = try engine.generateIncrementalFusedHybridLlama(
+            // Drop the profile string so the next ANE eval cannot smash a
+            // heap object that must survive the whole suite.
+            results.append(
+                try engine.dispatchLlamaTrunkDecode(LlamaDecodeRequest(
+                    trunk: trunk,
+                    plan: plan,
+                    bucket: bucket,
+                    sessionKind: "llama testing helper",
                     promptTokens: prompt,
                     effectiveMaxTokens: effectiveMaxTokens,
                     temperature: 0,
                     compileTimeMs: results.isEmpty ? compileTimeMs : 0,
-                    maxSeq: max(bucket, engine.compiledFusedHybridBucket),
-                    onStep: nil
-                )
-                // Drop the profile string so the next ANE eval cannot smash a
-                // heap object that must survive the whole suite.
-                results.append(
-                    GenerationResult(
-                        text: result.text,
-                        tokens: result.tokens,
-                        promptTokens: result.promptTokens,
-                        tokenLatenciesMs: result.tokenLatenciesMs,
-                        tokensPerSecond: result.tokensPerSecond,
-                        compileTimeMs: result.compileTimeMs,
-                        firstTokenLatencyMs: result.firstTokenLatencyMs,
-                        exactHeadBackend: result.exactHeadBackend,
-                        cachedBindingsEnabled: result.cachedBindingsEnabled,
-                        committedExactTokensPerPass: result.committedExactTokensPerPass,
-                        acceptedFutureTokensPerPass: result.acceptedFutureTokensPerPass,
-                        trunk: result.trunk,
-                        hopsPerToken: result.hopsPerToken,
-                        decodeProfileReport: nil
-                    )
-                )
-            case .splitHybrid:
-                guard let attention = metalAttention else {
-                    throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention unavailable for llama testing helper")
-                }
-                results.append(
-                    try engine.generateIncrementalHybridLlama(
-                        promptTokens: prompt,
-                        effectiveMaxTokens: effectiveMaxTokens,
-                        temperature: 0,
-                        compileTimeMs: results.isEmpty ? compileTimeMs : 0,
-                        maxSeq: bucket,
-                        metalAttention: attention,
-                        onStep: nil
-                    )
-                )
-            }
+                    preparation: preparation,
+                    maxSeq: trunk == .splitHybrid ? bucket : nil,
+                    dropsDecodeProfileReport: true
+                ))
+            )
         }
         return results
     }
@@ -2393,7 +2437,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         config: MultiModelConfig,
         topLevelPaths: LlamaTopLevelWeightPaths,
         weightDirURL: URL,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) throws -> LlamaTopLevelAssets {
         let tokenEmbedding = try loadWeightTablePreferringFloat32Sidecar(
             at: topLevelPaths.tokenEmbedding,
@@ -2511,7 +2555,7 @@ public struct RealModelInferenceEngine: ~Copyable {
     static func resolvedSpeculativeDraftLayerCount(
         config: MultiModelConfig,
         temperature: Float,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) -> Int? {
         guard config.architecture == .gpt2,
               temperature == 0,
@@ -2622,7 +2666,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         layer: Int,
         spatial: Int,
         input: [Float],
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) throws -> [Float] {
         let weightDirURL = URL(fileURLWithPath: weightDir, isDirectory: true)
         try validateDirectory(weightDirURL)
@@ -2670,7 +2714,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         layer: Int,
         spatial: Int,
         input: [Float],
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) throws -> [Float] {
         try compileAndEvalSingleLayerAttentionOutputsForTesting(
             config: config,
@@ -2688,7 +2732,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         layer: Int,
         spatial: Int,
         input: [Float],
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) throws -> AttentionTestingOutputs {
         let weightDirURL = URL(fileURLWithPath: weightDir, isDirectory: true)
         try validateDirectory(weightDirURL)
@@ -2813,7 +2857,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         weightDir: String,
         layer: Int = 0,
         spatial: Int,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) throws -> String {
         let weightDirURL = URL(fileURLWithPath: weightDir, isDirectory: true)
         try validateDirectory(weightDirURL)
@@ -2957,7 +3001,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 headDim: config.headDim,
                 preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                     config: config,
-                    environment: ProcessInfo.processInfo.environment
+                    environment: Self.processEnvironment
                 ),
                 timings: &timings
             )
@@ -3047,7 +3091,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 headDim: config.headDim,
                 preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                     config: config,
-                    environment: ProcessInfo.processInfo.environment
+                    environment: Self.processEnvironment
                 ),
                 timings: &timings
             )
@@ -3257,7 +3301,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 headDim: config.headDim,
                 preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                     config: config,
-                    environment: ProcessInfo.processInfo.environment
+                    environment: Self.processEnvironment
                 ),
                 postQKVHook: ropeHook,
                 timings: &timings
@@ -4119,7 +4163,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 headDim: config.headDim,
                 preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                     config: config,
-                    environment: ProcessInfo.processInfo.environment
+                    environment: Self.processEnvironment
                 ),
                 postQKVHook: ropeHook,
                 timings: &timings
@@ -4333,7 +4377,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 headDim: config.headDim,
                 preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                     config: config,
-                    environment: ProcessInfo.processInfo.environment
+                    environment: Self.processEnvironment
                 ),
                 postQKVHook: ropeHook,
                 timings: &timings
@@ -4532,7 +4576,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 headDim: config.headDim,
                 preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                     config: config,
-                    environment: ProcessInfo.processInfo.environment
+                    environment: Self.processEnvironment
                 ),
                 postQKVHook: ropeHook,
                 timings: &timings
@@ -4685,7 +4729,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 headDim: config.headDim,
                 preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                     config: config,
-                    environment: ProcessInfo.processInfo.environment
+                    environment: Self.processEnvironment
                 ),
                 postQKVHook: ropeHook,
                 timings: &timings
@@ -4793,7 +4837,7 @@ public struct RealModelInferenceEngine: ~Copyable {
     }
 
     static func requireANEHardwareTestsEnabled() throws {
-        guard ProcessInfo.processInfo.environment["ANE_HARDWARE_TESTS"] == "1" else {
+        guard Self.processEnvironment["ANE_HARDWARE_TESTS"] == "1" else {
             throw RealModelInferenceError.runtimeFailure("Set ANE_HARDWARE_TESTS=1 to run ANE hardware tests")
         }
         let handle = dlopen(
@@ -4870,7 +4914,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             if newLayers.count > 1,
                Self.usesHybridLayerInputRebinding(
                    architecture: config.architecture,
-                   environment: ProcessInfo.processInfo.environment
+                   environment: Self.processEnvironment
                ) {
                 for layerIndex in 1..<newLayers.count {
                     do {
@@ -5002,7 +5046,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             if newLayers.count > 1,
                Self.usesHybridLayerInputRebinding(
                    architecture: config.architecture,
-                   environment: ProcessInfo.processInfo.environment
+                   environment: Self.processEnvironment
                ) {
                 for layerIndex in 1..<newLayers.count {
                     do {
@@ -5191,7 +5235,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         // Pre-create cached Metal bindings for all layers (GPT-2 path)
         let cachedBindings: [MetalAttentionKernel.CachedLayerBindings]? = try Self.makeHybridCachedBindingsOrFallback(
             config: config,
-            environment: ProcessInfo.processInfo.environment
+            environment: Self.processEnvironment
         ) {
             try compiledHybridSurfaceHandles.map { handles in
                 try metalAttention.createCachedLayerBindings(
@@ -5209,14 +5253,14 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        if ProcessInfo.processInfo.environment["ESPRESSO_REALMODEL_DEBUG_HYBRID_CACHE"] == "1",
+        if Self.processEnvironment["ESPRESSO_REALMODEL_DEBUG_HYBRID_CACHE"] == "1",
            let firstHandles = compiledHybridSurfaceHandles.first {
             fputs(
                 "[hybrid-surface] qkvIn_row=\(IOSurfaceGetBytesPerRow(firstHandles.qkvIn)) qOut_row=\(IOSurfaceGetBytesPerRow(firstHandles.qOut)) ffnIn_row=\(IOSurfaceGetBytesPerRow(firstHandles.ffnIn)) ffnOut_row=\(IOSurfaceGetBytesPerRow(firstHandles.ffnOut)) laneSpatial=\(firstHandles.laneSpatial) maxSeq=\(firstHandles.maxSeq)\n",
                 stderr
             )
         }
-        let shouldDebugHybridCache = ProcessInfo.processInfo.environment["ESPRESSO_REALMODEL_DEBUG_HYBRID_CACHE"] == "1"
+        let shouldDebugHybridCache = Self.processEnvironment["ESPRESSO_REALMODEL_DEBUG_HYBRID_CACHE"] == "1"
 
         let xCur = TensorBuffer(count: config.dModel, zeroed: true)
         var decodeState: DecodeState
@@ -5253,7 +5297,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     dim: config.dModel,
                     preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                         config: config,
-                        environment: ProcessInfo.processInfo.environment
+                        environment: Self.processEnvironment
                     ),
                     readFinalOutputIntoXCur: !useANEGreedyHead,
                     cachedBindings: cachedBindings,
@@ -5412,7 +5456,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     dim: config.dModel,
                     preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                         config: config,
-                        environment: ProcessInfo.processInfo.environment
+                        environment: Self.processEnvironment
                     ),
                     readFinalOutputIntoXCur: !useANEGreedyHead,
                     cachedBindings: cachedBindings,
@@ -5881,7 +5925,7 @@ public struct RealModelInferenceEngine: ~Copyable {
     }
 
     private func encodePrompt(_ prompt: String) throws -> [TokenID] {
-        let environment = ProcessInfo.processInfo.environment
+        let environment = Self.processEnvironment
         let textToEncode: String
         // CLI `preparedGeneratePrompt` may already apply the same wrap.
         if environment["ESPRESSO_RAW_PROMPT"] == "1" || prompt.hasPrefix("<|im_start|>") {
@@ -6217,6 +6261,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         compileTimeMs: Double,
         maxSeq: Int,
         metalAttention: MetalAttentionKernel,
+        plan: ResolvedDecodePlan,
         onStep: ((GenerationStep) -> Void)?,
         isCancelled: (() -> Bool)? = nil
     ) throws -> GenerationResult {
@@ -6230,11 +6275,12 @@ public struct RealModelInferenceEngine: ~Copyable {
             )
         }
 
-        if try Self.resolvedTrunk(
-            config: config,
-            environment: ProcessInfo.processInfo.environment
-        ) == .exactCPU {
-            return try generateIncrementalExactCPULlama(
+        if plan.trunk == .exactCPU {
+            return try dispatchLlamaTrunkDecode(LlamaDecodeRequest(
+                trunk: .exactCPU,
+                plan: plan,
+                bucket: maxSeq,
+                sessionKind: "llama",
                 promptTokens: promptTokens,
                 effectiveMaxTokens: effectiveMaxTokens,
                 temperature: temperature,
@@ -6243,7 +6289,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 maxSeq: maxSeq,
                 onStep: onStep,
                 isCancelled: isCancelled
-            )
+            ))
         }
 
         try ForwardPass.initializeHybridDecodeCaches(
@@ -6254,7 +6300,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         // Pre-create cached decode-surface metadata for all layers.
         let cachedBindings: [MetalAttentionKernel.CachedLayerBindings]? = try Self.makeHybridCachedBindingsOrFallback(
             config: config,
-            environment: ProcessInfo.processInfo.environment
+            environment: Self.processEnvironment
         ) {
             try compiledHybridSurfaceHandles.map { handles in
                 try metalAttention.createCachedLayerBindings(
@@ -6398,7 +6444,7 @@ public struct RealModelInferenceEngine: ~Copyable {
 
         let useCPUExactQKV = Self.prefersCPUExactQKV(
             config: config,
-            environment: ProcessInfo.processInfo.environment
+            environment: Self.processEnvironment
         )
         let cpuExactQKVLayerWeights: [LlamaCPUQKVWeights]? = if useCPUExactQKV {
             try (0..<config.nLayer).map { layerIndex in
@@ -6533,7 +6579,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     headDim: headDim,
                     preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                         config: config,
-                        environment: ProcessInfo.processInfo.environment
+                        environment: Self.processEnvironment
                     ),
                     qkvOverride: cpuExactQKV,
                     postQKVHook: metalRoPEConfig != nil ? nil : ropeHook,
@@ -6682,7 +6728,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                     headDim: headDim,
                     preferCPUDecodeAttention: Self.prefersCPUDecodeAttention(
                         config: config,
-                        environment: ProcessInfo.processInfo.environment
+                        environment: Self.processEnvironment
                     ),
                     qkvOverride: cpuExactQKV,
                     postQKVHook: metalRoPEConfig != nil ? nil : ropeHook,
@@ -7103,7 +7149,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         let layerRange = sourceLayerRange ?? (0..<config.nLayer)
         let useDonorDelta = supportsHybridDonorDelta(
             config: config,
-            environment: ProcessInfo.processInfo.environment
+            environment: Self.processEnvironment
         )
         var donorHexIDs: HybridDecodeKernelSet.DonorHexIDs? = nil
         return try LayerStorage<HybridDecodeKernelSet>(count: layerRange.count, throwingInitializer: { localLayerIndex in
@@ -7135,7 +7181,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         config: MultiModelConfig,
         weightDirURL: URL,
         bucket: Int,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) throws -> LayerStorage<CompiledLayer> {
         try LayerStorage<CompiledLayer>(count: config.nLayer, throwingInitializer: { layerIndex in
             try compileLayer(
@@ -7721,7 +7767,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         config: MultiModelConfig,
         weightDirURL: URL,
         spatial: Int,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) throws -> CompiledLayer {
         let paths = LayerWeightPaths.forLayer(layerIndex, config: config, blobDir: weightDirURL.path)
         let ioBytes = try ANEShape(channels: config.dModel, spatial: spatial).byteSize(for: .fp32)
@@ -7808,7 +7854,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         outputBytes: [Int],
         weightDirURL: URL,
         spatial: Int,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) throws -> ANEKernel {
         var optimized = graph
         ANEOptimizationPipeline.optimize(&optimized)
@@ -7917,7 +7963,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         spatial: Int,
         inputDType: ANEDType = .fp32,
         outputDType: ANEDType = .fp32,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) throws -> CompiledHead {
         var graph = buildGPT2HeadGraph(
             config: config,
@@ -8240,7 +8286,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         config: MultiModelConfig,
         paths: LayerWeightPaths,
         spatial: Int,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) -> ANEGraph {
         var graph = ANEGraph()
         let prefix = "layer\(layerIndex)"
@@ -8333,7 +8379,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         config: MultiModelConfig,
         paths: LayerWeightPaths,
         spatial: Int,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) -> ANEGraph {
         var graph = ANEGraph()
         let prefix = "layer\(layerIndex)"
@@ -8389,7 +8435,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         spatial: Int,
         inputDType: ANEDType = .fp32,
         outputDType: ANEDType = .fp32,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = Self.processEnvironment
     ) -> ANEGraph {
         var graph = ANEGraph()
         let input = try! graph.input(
@@ -8959,7 +9005,7 @@ public struct RealModelInferenceEngine: ~Copyable {
 
     private mutating func exactClassifierArgmax(_ hidden: [Float]) -> Int {
         precondition(hidden.count == config.dModel)
-        if let dumpPath = ProcessInfo.processInfo.environment["ESPRESSO_DUMP_LM_HEAD_HIDDEN"],
+        if let dumpPath = Self.processEnvironment["ESPRESSO_DUMP_LM_HEAD_HIDDEN"],
            !dumpPath.isEmpty {
             Self.appendLMHeadHiddenDump(hidden, to: dumpPath)
         }

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -515,10 +515,6 @@ public struct RealModelInferenceEngine: ~Copyable {
         )
     }
 
-    static func isHybridFallbackDisabled(environment: [String: String]) -> Bool {
-        DecodePathPolicy.optionsFromEnvironment(environment).disableHybridFallback
-    }
-
     /// Resolves the llama serving ``Trunk``, refusing to leave the ANE silently.
     ///
     /// With `ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK=1`, landing on the pure-CPU trunk is

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -1523,11 +1523,19 @@ public struct RealModelInferenceEngine: ~Copyable {
         }
     }
 
-    private var compiledBucket: Int
+    /// Per-trunk compile readiness; the ensure functions below are the only writers.
+    private var baselineReadiness = CompiledReadiness<BaselineCompiledRuntime>.notCompiled
+    private var splitHybridReadiness = CompiledReadiness<SplitHybridCompiledRuntime>.notCompiled
+    private var fusedHybridReadiness = CompiledReadiness<FusedHybridCompiledRuntime>.notCompiled
+    /// Bucket of the last fully resident split-hybrid layer-program set.
+    ///
+    /// Incremental-compile watermark consulted only by ``ensureHybridCompiled``
+    /// (so a mid-compile failure never recompiles finished layers) and by the
+    /// dispatch max-sequence defaults; loop readiness itself is carried by
+    /// ``splitHybridReadiness``.
+    private var splitHybridLayerBucket = 0
     private var compiledLayers: LayerStorage<CompiledLayer>
-    private var firstLayerInputSurface: IOSurfaceRef?
     private var compiledHead: LayerStorage<CompiledHead>
-    private var compiledHybridBucket: Int
     private var compiledHybridLayers: LayerStorage<HybridDecodeKernelSet>
     private var compiledHybridSurfaceHandles: [HybridDecodeSurfaceHandles]
     private var compiledHybridLlamaQKNormWeights: [LlamaQKNormWeights?]
@@ -1536,7 +1544,6 @@ public struct RealModelInferenceEngine: ~Copyable {
     private var compiledHybridGreedyNorm: LayerStorage<CompiledHead>
     private var compiledHybridGreedyClassifier: LayerStorage<CompiledClassifier>
     private var compiledHybridGreedySpatial: Int
-    private var compiledFusedHybridBucket: Int
     private var compiledFusedHybridLayers: LayerStorage<FusedHybridDecodeLayerKernelSet>
     private var compiledFusedHybridSurfaceHandles: [FusedHybridDecodeSurfaceHandles]
     private var hybridMetalAttention: MetalAttentionKernel?
@@ -1576,11 +1583,8 @@ public struct RealModelInferenceEngine: ~Copyable {
         self.weightDirURL = weightDirURL
         self.tokenizer = tokenizer
         self.assets = assets
-        self.compiledBucket = 0
         self.compiledLayers = Self.emptyStorage(CompiledLayer.self)
-        self.firstLayerInputSurface = nil
         self.compiledHead = Self.emptyStorage(CompiledHead.self)
-        self.compiledHybridBucket = 0
         self.compiledHybridLayers = Self.emptyStorage(HybridDecodeKernelSet.self)
         self.compiledHybridSurfaceHandles = []
         self.compiledHybridLlamaQKNormWeights = []
@@ -1589,7 +1593,6 @@ public struct RealModelInferenceEngine: ~Copyable {
         self.compiledHybridGreedyNorm = Self.emptyStorage(CompiledHead.self)
         self.compiledHybridGreedyClassifier = Self.emptyStorage(CompiledClassifier.self)
         self.compiledHybridGreedySpatial = 0
-        self.compiledFusedHybridBucket = 0
         self.compiledFusedHybridLayers = Self.emptyStorage(FusedHybridDecodeLayerKernelSet.self)
         self.compiledFusedHybridSurfaceHandles = []
         self.hybridMetalAttention = nil
@@ -1709,7 +1712,7 @@ public struct RealModelInferenceEngine: ~Copyable {
         }
         if trunk == .splitHybrid {
             let compileStart = DispatchTime.now().uptimeNanoseconds
-            let compileDidRun = try ensureHybridCompiledLlama(bucket: bucket)
+            let compileDidRun = try ensureHybridCompiled(bucket: bucket)
             guard let metalAttention = hybridMetalAttention else {
                 throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention unavailable for \(sessionKind)")
             }
@@ -1759,7 +1762,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 temperature: request.temperature,
                 topP: request.topP,
                 compileTimeMs: sessionCompileTimeMs,
-                maxSeq: request.maxSeq ?? max(request.bucket, compiledFusedHybridBucket),
+                maxSeq: request.maxSeq ?? max(request.bucket, fusedHybridReadiness.runtime?.bucket ?? request.bucket),
                 onStep: request.onStep,
                 isCancelled: request.isCancelled
             )
@@ -1790,7 +1793,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                 temperature: request.temperature,
                 topP: request.topP,
                 compileTimeMs: sessionCompileTimeMs,
-                maxSeq: request.maxSeq ?? max(request.bucket, compiledHybridBucket),
+                maxSeq: request.maxSeq ?? max(request.bucket, splitHybridLayerBucket),
                 metalAttention: metalAttention,
                 onStep: request.onStep,
                 isCancelled: request.isCancelled
@@ -1922,21 +1925,22 @@ public struct RealModelInferenceEngine: ~Copyable {
         do {
             let hybridDidRun = try ensureHybridCompiled(bucket: bucket)
             compileDidRun = compileDidRun || hybridDidRun
-            useHybridFastPath =
-                compiledHybridLayers.count == config.nLayer &&
-                compiledHybridSurfaceHandles.count == config.nLayer &&
-                compiledHybridHead.count == 1 &&
-                hybridMetalAttention != nil
-            if !useHybridFastPath, !plan.allowsHybridFallback {
-                throw RealModelInferenceError.hybridFallbackDisabled(
-                    stage: "hybrid decode compile",
-                    reason: """
-                        hybrid decode state is incomplete: layers=\(compiledHybridLayers.count)/\(config.nLayer) \
-                        surfaces=\(compiledHybridSurfaceHandles.count)/\(config.nLayer) \
-                        head=\(compiledHybridHead.count)/1 \
-                        metalAttention=\(hybridMetalAttention != nil)
-                        """
-                )
+            switch splitHybridReadiness {
+            case .compiled:
+                useHybridFastPath = true
+            case .notCompiled:
+                useHybridFastPath = false
+                guard plan.allowsHybridFallback else {
+                    throw RealModelInferenceError.hybridFallbackDisabled(
+                        stage: "hybrid decode compile",
+                        reason: """
+                            hybrid decode state is incomplete: layers=\(compiledHybridLayers.count)/\(config.nLayer) \
+                            surfaces=\(compiledHybridSurfaceHandles.count)/\(config.nLayer) \
+                            head=\(compiledHybridHead.count)/1 \
+                            metalAttention=\(hybridMetalAttention != nil)
+                            """
+                    )
+                }
             }
         } catch let error as RealModelInferenceError {
             // A disabled-fallback error is the answer, not something to recover from.
@@ -2029,9 +2033,14 @@ public struct RealModelInferenceEngine: ~Copyable {
         let compileEnd = DispatchTime.now().uptimeNanoseconds
         let compileTimeMs = compileDidRun ? Self.milliseconds(from: compileEnd - compileStart) : 0
 
-        guard let inputSurface = firstLayerInputSurface, compiledLayers.count == config.nLayer, compiledHead.count == 1 else {
+        let baseline: BaselineCompiledRuntime
+        switch baselineReadiness {
+        case .compiled(let runtime):
+            baseline = runtime
+        case .notCompiled:
             throw RealModelInferenceError.runtimeFailure("Compiled ANE surfaces are unavailable")
         }
+        let inputSurface = baseline.inputSurface
 
         let generationStart = DispatchTime.now().uptimeNanoseconds
         let tokenizer = self.tokenizer
@@ -2044,7 +2053,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             startNanos: generationStart
         )
         var rng = SystemRandomNumberGenerator()
-        let activeBucket = compiledBucket
+        let activeBucket = baseline.bucket
 
         for _ in 0..<effectiveMaxTokens {
             let sequenceLength = emission.allTokensCount
@@ -4817,8 +4826,11 @@ public struct RealModelInferenceEngine: ~Copyable {
     }
 
     private mutating func ensureCompiled(bucket: Int) throws -> Bool {
-        guard compiledBucket < bucket else {
+        switch baselineReadiness {
+        case .compiled(let runtime) where runtime.bucket >= bucket:
             return false
+        case .compiled, .notCompiled:
+            break
         }
 
         let newLayers = try Self.compileLayers(
@@ -4842,144 +4854,30 @@ public struct RealModelInferenceEngine: ~Copyable {
         }
         compiledLayers = newLayers
         compiledHead = newHead
-        firstLayerInputSurface = newInputSurface
-        compiledBucket = bucket
+        baselineReadiness = .compiled(BaselineCompiledRuntime(bucket: bucket, inputSurface: newInputSurface))
         return true
     }
 
+    /// Compiles split-hybrid decode programs when the resident set covers less context.
+    ///
+    /// One parameterized implementation serves both model families: the former
+    /// GPT-2/llama ensure twins differed only in surface-handle geometry,
+    /// output-head compilation, and error prefixes. Split-hybrid readiness
+    /// transitions to `.compiled` after the output-head section, before the
+    /// family-specific greedy-classifier section — a greedy-head compile failure
+    /// must not unready the trunk's decode programs, matching the former flag
+    /// semantics where such failures still served hybrid decode via CPU logits.
     private mutating func ensureHybridCompiled(bucket: Int) throws -> Bool {
         var didCompile = false
 
-        if compiledHybridBucket < bucket {
-            let newLayers = try Self.compileHybridLayers(
-                config: config,
-                weightDirURL: weightDirURL,
-                maxSeq: bucket
-            )
-            let newQKNormWeights = try Self.loadHybridLlamaQKNormWeights(
-                config: config,
-                weightDirURL: weightDirURL
-            )
-            var newSurfaceHandles: [HybridDecodeSurfaceHandles] = []
-            newSurfaceHandles.reserveCapacity(newLayers.count)
-            for layerIndex in 0..<newLayers.count {
-                do {
-                    newSurfaceHandles.append(
-                        try HybridDecodeSurfaceHandles(
-                            kernels: newLayers[layerIndex],
-                            logicalMaxSeq: bucket
-                        )
-                    )
-                } catch {
-                    throw RealModelInferenceError.runtimeFailure(
-                        "Hybrid decode surfaces unavailable for layer \(layerIndex): \(error)"
-                    )
-                }
-            }
-            if newLayers.count > 1,
-               Self.usesHybridLayerInputRebinding(
-                   architecture: config.architecture,
-                   environment: Self.processEnvironment
-               ) {
-                for layerIndex in 1..<newLayers.count {
-                    do {
-                        try newLayers[layerIndex].decodeQKVOnly.rebindInput(
-                            at: 0,
-                            to: newSurfaceHandles[layerIndex - 1].ffnOut
-                        )
-                    } catch {
-                        throw RealModelInferenceError.runtimeFailure(
-                            "Hybrid decode chaining unavailable for layer \(layerIndex): \(error)"
-                        )
-                    }
-                }
-            }
+        // Both flavors share every program up to the output head; only the
+        // surface-handle geometry and head compilation differ.
+        let isLlama = config.architecture == .llama
+        let surfaceDim = isLlama ? config.dModel : ModelConfig.dim
+        let surfaceQDim: Int? = isLlama ? config.attentionDim : nil
+        let surfaceKVDim: Int? = isLlama ? config.nKVHead * config.headDim : nil
 
-            compiledHybridLayers = newLayers
-            compiledHybridSurfaceHandles = newSurfaceHandles
-            compiledHybridLlamaQKNormWeights = newQKNormWeights
-            compiledHybridBucket = bucket
-            didCompile = true
-        }
-
-        if compiledHybridLlamaQKNormWeights.count != config.nLayer {
-            compiledHybridLlamaQKNormWeights = try Self.loadHybridLlamaQKNormWeights(
-                config: config,
-                weightDirURL: weightDirURL
-            )
-        }
-
-        if hybridMetalAttention == nil {
-            do {
-                hybridMetalAttention = try MetalAttentionKernel()
-            } catch {
-                throw RealModelInferenceError.runtimeFailure("Hybrid Metal attention initialization failed: \(error)")
-            }
-            didCompile = true
-        }
-
-        let hybridHeadSpatial = Self.incrementalHeadSpatial(channels: config.dModel)
-        if compiledHybridHead.count != 1 || compiledHybridHeadSpatial != hybridHeadSpatial {
-            compiledHybridHead = try LayerStorage<CompiledHead>(count: 1, throwingInitializer: { _ in
-                try Self.compileHead(
-                    config: config,
-                    weightDirURL: weightDirURL,
-                    assets: gpt2Assets,
-                    spatial: hybridHeadSpatial
-                )
-            })
-            compiledHybridHeadSpatial = hybridHeadSpatial
-            try Self.zeroSurface(compiledHybridHead[0].inputSurface)
-            didCompile = true
-        }
-
-        if classifierStrategy.usesANEClassifier {
-            if compiledHybridGreedyNorm.count != 1 ||
-                compiledHybridGreedyClassifier.count != 1 ||
-                compiledHybridGreedySpatial != hybridHeadSpatial {
-                compiledHybridGreedyNorm = try LayerStorage<CompiledHead>(count: 1, throwingInitializer: { _ in
-                    try Self.compileHead(
-                        config: config,
-                        weightDirURL: weightDirURL,
-                        assets: gpt2Assets,
-                        spatial: hybridHeadSpatial,
-                        inputDType: .fp16,
-                        outputDType: .fp16
-                    )
-                })
-                compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
-                    try Self.compileClassifier(
-                        config: config,
-                        assets: gpt2Assets,
-                        spatial: hybridHeadSpatial
-                    )
-                })
-                compiledHybridGreedySpatial = hybridHeadSpatial
-                try compiledHybridGreedyClassifier[0].kernel.rebindInput(
-                    at: 0,
-                    to: compiledHybridGreedyNorm[0].outputSurface
-                )
-                didCompile = true
-            }
-
-            if compiledHybridGreedyNorm.count == 1,
-               compiledHybridGreedyClassifier.count == 1,
-               let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
-                try compiledHybridGreedyNorm[0].kernel.rebindInput(at: 0, to: finalSurface)
-                try compiledHybridGreedyClassifier[0].kernel.rebindInput(
-                    at: 0,
-                    to: compiledHybridGreedyNorm[0].outputSurface
-                )
-            }
-        }
-
-        return didCompile
-    }
-
-    private mutating func ensureHybridCompiledLlama(bucket: Int) throws -> Bool {
-        var didCompile = false
-
-        if compiledHybridBucket < bucket {
+        if splitHybridLayerBucket < bucket {
             let newLayers = try Self.compileHybridLayers(
                 config: config,
                 weightDirURL: weightDirURL,
@@ -4997,14 +4895,14 @@ public struct RealModelInferenceEngine: ~Copyable {
                         try HybridDecodeSurfaceHandles(
                             kernels: newLayers[layerIndex],
                             logicalMaxSeq: bucket,
-                            dim: config.dModel,
-                            qDim: config.attentionDim,
-                            kvDim: config.nKVHead * config.headDim
+                            dim: surfaceDim,
+                            qDim: surfaceQDim,
+                            kvDim: surfaceKVDim
                         )
                     )
                 } catch {
                     throw RealModelInferenceError.runtimeFailure(
-                        "Llama hybrid decode surfaces unavailable for layer \(layerIndex): \(error)"
+                        "\(isLlama ? "Llama hybrid" : "Hybrid") decode surfaces unavailable for layer \(layerIndex): \(error)"
                     )
                 }
             }
@@ -5021,7 +4919,7 @@ public struct RealModelInferenceEngine: ~Copyable {
                         )
                     } catch {
                         throw RealModelInferenceError.runtimeFailure(
-                            "Llama hybrid decode chaining unavailable for layer \(layerIndex): \(error)"
+                            "\(isLlama ? "Llama hybrid" : "Hybrid") decode chaining unavailable for layer \(layerIndex): \(error)"
                         )
                     }
                 }
@@ -5030,7 +4928,7 @@ public struct RealModelInferenceEngine: ~Copyable {
             compiledHybridLayers = newLayers
             compiledHybridSurfaceHandles = newSurfaceHandles
             compiledHybridLlamaQKNormWeights = newQKNormWeights
-            compiledHybridBucket = bucket
+            splitHybridLayerBucket = bucket
             didCompile = true
         }
 
@@ -5045,21 +4943,28 @@ public struct RealModelInferenceEngine: ~Copyable {
             do {
                 hybridMetalAttention = try MetalAttentionKernel()
             } catch {
-                throw RealModelInferenceError.runtimeFailure("Llama hybrid Metal attention initialization failed: \(error)")
+                throw RealModelInferenceError.runtimeFailure(
+                    "\(isLlama ? "Llama hybrid" : "Hybrid") Metal attention initialization failed: \(error)"
+                )
             }
             didCompile = true
         }
 
         let hybridHeadSpatial = Self.incrementalHeadSpatial(channels: config.dModel)
-        let greedyHeadMode = hybridGreedyHeadMode()
-
-        // Compile RMSNorm head (no beta) for llama
         if compiledHybridHead.count != 1 || compiledHybridHeadSpatial != hybridHeadSpatial {
             compiledHybridHead = try LayerStorage<CompiledHead>(count: 1, throwingInitializer: { _ in
-                try Self.compileLlamaHead(
+                if isLlama {
+                    return try Self.compileLlamaHead(
+                        config: config,
+                        weightDirURL: weightDirURL,
+                        assets: llamaAssets,
+                        spatial: hybridHeadSpatial
+                    )
+                }
+                return try Self.compileHead(
                     config: config,
                     weightDirURL: weightDirURL,
-                    assets: llamaAssets,
+                    assets: gpt2Assets,
                     spatial: hybridHeadSpatial
                 )
             })
@@ -5068,78 +4973,131 @@ public struct RealModelInferenceEngine: ~Copyable {
             didCompile = true
         }
 
+        // Readiness transition: every program the split-hybrid decode loop
+        // requires is now resident, independent of the greedy head below.
+        if let runtime = SplitHybridCompiledRuntime(
+            bucket: max(bucket, splitHybridLayerBucket),
+            layerCount: compiledHybridLayers.count,
+            surfaceHandleCount: compiledHybridSurfaceHandles.count,
+            expectedLayerCount: config.nLayer,
+            headCount: compiledHybridHead.count,
+            qKNormCount: isLlama ? compiledHybridLlamaQKNormWeights.count : nil,
+            headSpatial: compiledHybridHeadSpatial
+        ) {
+            splitHybridReadiness = .compiled(runtime)
+        } else {
+            splitHybridReadiness = .notCompiled
+        }
+
         if classifierStrategy.usesANEClassifier {
-            switch greedyHeadMode {
-            case .classifierOnlyFactored:
-                if compiledHybridGreedyNorm.count != 0 {
-                    compiledHybridGreedyNorm = Self.emptyStorage(CompiledHead.self)
-                    didCompile = true
-                }
-                if compiledHybridGreedyClassifier.count != 1 {
-                    do {
+            if isLlama {
+                switch hybridGreedyHeadMode() {
+                case .classifierOnlyFactored:
+                    if compiledHybridGreedyNorm.count != 0 {
+                        compiledHybridGreedyNorm = Self.emptyStorage(CompiledHead.self)
+                        didCompile = true
+                    }
+                    if compiledHybridGreedyClassifier.count != 1 {
+                        do {
+                            compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
+                                try Self.compileLlamaFactoredClassifier(
+                                    config: config,
+                                    assets: llamaAssets,
+                                    spatial: hybridHeadSpatial
+                                )
+                            })
+                        } catch {
+                            fputs(
+                                "[RealModelInference] Llama factored classifier compile failed; falling back to dense ANE classifier: \(error)\n",
+                                stderr
+                            )
+                            compiledHybridGreedyClassifier = Self.emptyStorage(CompiledClassifier.self)
+                        }
+                        didCompile = true
+                    }
+                    if compiledHybridGreedyClassifier.count == 1,
+                       let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
+                        try compiledHybridGreedyClassifier[0].kernel.rebindInput(at: 0, to: finalSurface)
+                    }
+                case .classifierOnlyFused:
+                    if compiledHybridGreedyNorm.count != 0 {
+                        compiledHybridGreedyNorm = Self.emptyStorage(CompiledHead.self)
+                        didCompile = true
+                    }
+                    if compiledHybridGreedyClassifier.count != 1 {
                         compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
-                            try Self.compileLlamaFactoredClassifier(
+                            try Self.compileLlamaRMSNormClassifier(
                                 config: config,
                                 assets: llamaAssets,
                                 spatial: hybridHeadSpatial
                             )
                         })
-                    } catch {
-                        fputs(
-                            "[RealModelInference] Llama factored classifier compile failed; falling back to dense ANE classifier: \(error)\n",
-                            stderr
-                        )
-                        compiledHybridGreedyClassifier = Self.emptyStorage(CompiledClassifier.self)
+                        didCompile = true
                     }
-                    didCompile = true
-                }
-                if compiledHybridGreedyClassifier.count == 1,
-                   let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
-                    try compiledHybridGreedyClassifier[0].kernel.rebindInput(at: 0, to: finalSurface)
-                }
-            case .classifierOnlyFused:
-                if compiledHybridGreedyNorm.count != 0 {
-                    compiledHybridGreedyNorm = Self.emptyStorage(CompiledHead.self)
-                    didCompile = true
-                }
-                if compiledHybridGreedyClassifier.count != 1 {
-                    compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
-                        try Self.compileLlamaRMSNormClassifier(
-                            config: config,
-                            assets: llamaAssets,
-                            spatial: hybridHeadSpatial
+                    if compiledHybridGreedyClassifier.count == 1,
+                       let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
+                        try compiledHybridGreedyClassifier[0].kernel.rebindInput(at: 0, to: finalSurface)
+                    }
+                case .normThenClassifier:
+                    if compiledHybridGreedyNorm.count != 1 || compiledHybridGreedySpatial != hybridHeadSpatial {
+                        compiledHybridGreedyNorm = try LayerStorage<CompiledHead>(count: 1, throwingInitializer: { _ in
+                            try Self.compileLlamaHead(
+                                config: config,
+                                weightDirURL: weightDirURL,
+                                assets: llamaAssets,
+                                spatial: hybridHeadSpatial,
+                                inputDType: .fp16,
+                                outputDType: .fp16
+                            )
+                        })
+                        compiledHybridGreedySpatial = hybridHeadSpatial
+                        didCompile = true
+                    }
+
+                    if compiledHybridGreedyClassifier.count != 1 {
+                        compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
+                            try Self.compileLlamaClassifier(
+                                config: config,
+                                assets: llamaAssets,
+                                spatial: hybridHeadSpatial
+                            )
+                        })
+                        try compiledHybridGreedyClassifier[0].kernel.rebindInput(
+                            at: 0,
+                            to: compiledHybridGreedyNorm[0].outputSurface
                         )
-                    })
-                    didCompile = true
+                        didCompile = true
+                    }
+
+                    if compiledHybridGreedyClassifier.count == 1 {
+                        try compiledHybridGreedyClassifier[0].kernel.rebindInput(
+                            at: 0,
+                            to: compiledHybridGreedyNorm[0].outputSurface
+                        )
+                    }
                 }
-                if compiledHybridGreedyClassifier.count == 1,
-                   let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
-                    try compiledHybridGreedyClassifier[0].kernel.rebindInput(at: 0, to: finalSurface)
-                }
-            case .normThenClassifier:
-                if compiledHybridGreedyNorm.count != 1 || compiledHybridGreedySpatial != hybridHeadSpatial {
+            } else {
+                if compiledHybridGreedyNorm.count != 1 ||
+                    compiledHybridGreedyClassifier.count != 1 ||
+                    compiledHybridGreedySpatial != hybridHeadSpatial {
                     compiledHybridGreedyNorm = try LayerStorage<CompiledHead>(count: 1, throwingInitializer: { _ in
-                        try Self.compileLlamaHead(
+                        try Self.compileHead(
                             config: config,
                             weightDirURL: weightDirURL,
-                            assets: llamaAssets,
+                            assets: gpt2Assets,
                             spatial: hybridHeadSpatial,
                             inputDType: .fp16,
                             outputDType: .fp16
                         )
                     })
-                    compiledHybridGreedySpatial = hybridHeadSpatial
-                    didCompile = true
-                }
-
-                if compiledHybridGreedyClassifier.count != 1 {
                     compiledHybridGreedyClassifier = try LayerStorage<CompiledClassifier>(count: 1, throwingInitializer: { _ in
-                        try Self.compileLlamaClassifier(
+                        try Self.compileClassifier(
                             config: config,
-                            assets: llamaAssets,
+                            assets: gpt2Assets,
                             spatial: hybridHeadSpatial
                         )
                     })
+                    compiledHybridGreedySpatial = hybridHeadSpatial
                     try compiledHybridGreedyClassifier[0].kernel.rebindInput(
                         at: 0,
                         to: compiledHybridGreedyNorm[0].outputSurface
@@ -5147,7 +5105,10 @@ public struct RealModelInferenceEngine: ~Copyable {
                     didCompile = true
                 }
 
-                if compiledHybridGreedyClassifier.count == 1 {
+                if compiledHybridGreedyNorm.count == 1,
+                   compiledHybridGreedyClassifier.count == 1,
+                   let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
+                    try compiledHybridGreedyNorm[0].kernel.rebindInput(at: 0, to: finalSurface)
                     try compiledHybridGreedyClassifier[0].kernel.rebindInput(
                         at: 0,
                         to: compiledHybridGreedyNorm[0].outputSurface
@@ -5156,7 +5117,8 @@ public struct RealModelInferenceEngine: ~Copyable {
             }
         }
 
-        if compiledHybridGreedyNorm.count == 1,
+        if isLlama,
+           compiledHybridGreedyNorm.count == 1,
            let finalSurface = compiledHybridSurfaceHandles.last?.ffnOut {
             try compiledHybridGreedyNorm[0].kernel.rebindInput(at: 0, to: finalSurface)
         }
@@ -5185,10 +5147,10 @@ public struct RealModelInferenceEngine: ~Copyable {
         onStep: ((GenerationStep) -> Void)?,
         isCancelled: (() -> Bool)? = nil
     ) throws -> GenerationResult {
-        guard compiledHybridLayers.count == config.nLayer,
-              compiledHybridSurfaceHandles.count == config.nLayer,
-              compiledHybridHead.count == 1,
-              compiledHybridHeadSpatial > 0 else {
+        switch splitHybridReadiness {
+        case .compiled:
+            break
+        case .notCompiled:
             throw RealModelInferenceError.runtimeFailure("Hybrid decode state is unavailable")
         }
 
@@ -5894,10 +5856,11 @@ public struct RealModelInferenceEngine: ~Copyable {
     }
 
     private mutating func ensureFusedHybridCompiled(bucket: Int) throws -> Bool {
-        if compiledFusedHybridBucket >= bucket,
-           compiledFusedHybridLayers.count == config.nLayer,
-           compiledFusedHybridSurfaceHandles.count == config.nLayer {
+        switch fusedHybridReadiness {
+        case .compiled(let runtime) where runtime.bucket >= bucket:
             return false
+        case .compiled, .notCompiled:
+            break
         }
 
         let newLayers: LayerStorage<FusedHybridDecodeLayerKernelSet>
@@ -5930,7 +5893,16 @@ public struct RealModelInferenceEngine: ~Copyable {
 
         compiledFusedHybridLayers = newLayers
         compiledFusedHybridSurfaceHandles = newSurfaceHandles
-        compiledFusedHybridBucket = bucket
+        if let runtime = FusedHybridCompiledRuntime(
+            bucket: bucket,
+            layerCount: compiledFusedHybridLayers.count,
+            surfaceHandleCount: compiledFusedHybridSurfaceHandles.count,
+            expectedLayerCount: config.nLayer
+        ) {
+            fusedHybridReadiness = .compiled(runtime)
+        } else {
+            fusedHybridReadiness = .notCompiled
+        }
         return true
     }
 
@@ -5980,8 +5952,10 @@ public struct RealModelInferenceEngine: ~Copyable {
         onStep: ((GenerationStep) -> Void)?,
         isCancelled: (() -> Bool)? = nil
     ) throws -> GenerationResult {
-        guard compiledFusedHybridLayers.count == config.nLayer,
-              compiledFusedHybridSurfaceHandles.count == config.nLayer else {
+        switch fusedHybridReadiness {
+        case .compiled:
+            break
+        case .notCompiled:
             throw Self.fusedHybridFallbackError(
                 reason: """
                     fused N=1 state is incomplete: \
@@ -6122,11 +6096,10 @@ public struct RealModelInferenceEngine: ~Copyable {
         onStep: ((GenerationStep) -> Void)?,
         isCancelled: (() -> Bool)? = nil
     ) throws -> GenerationResult {
-        guard compiledHybridLayers.count == config.nLayer,
-              compiledHybridSurfaceHandles.count == config.nLayer,
-              compiledHybridLlamaQKNormWeights.count == config.nLayer,
-              compiledHybridHead.count == 1,
-              compiledHybridHeadSpatial > 0 else {
+        switch splitHybridReadiness {
+        case .compiled:
+            break
+        case .notCompiled:
             throw RealModelInferenceError.runtimeFailure(
                 "Llama hybrid decode state is unavailable: layers=\(compiledHybridLayers.count)/\(config.nLayer) surfaces=\(compiledHybridSurfaceHandles.count)/\(config.nLayer) qkNorms=\(compiledHybridLlamaQKNormWeights.count)/\(config.nLayer) head=\(compiledHybridHead.count) headSpatial=\(compiledHybridHeadSpatial)"
             )

--- a/Sources/RealModelInference/RealModelInferenceEngine.swift
+++ b/Sources/RealModelInference/RealModelInferenceEngine.swift
@@ -1666,7 +1666,6 @@ public struct RealModelInferenceEngine: ~Copyable {
     /// One unit of llama serving work routed through the single ``Trunk`` dispatch point.
     private struct LlamaDecodeRequest {
         let trunk: Trunk
-        let plan: ResolvedDecodePlan
         let bucket: Int
         /// Names the caller in attention-unavailability errors ("llama" vs "llama testing helper").
         let sessionKind: String
@@ -1797,7 +1796,6 @@ public struct RealModelInferenceEngine: ~Copyable {
                 compileTimeMs: sessionCompileTimeMs,
                 maxSeq: request.maxSeq ?? max(request.bucket, compiledHybridBucket),
                 metalAttention: metalAttention,
-                plan: request.plan,
                 onStep: request.onStep,
                 isCancelled: request.isCancelled
             )
@@ -1909,7 +1907,6 @@ public struct RealModelInferenceEngine: ~Copyable {
             )
             return try dispatchLlamaTrunkDecode(LlamaDecodeRequest(
                 trunk: trunk,
-                plan: plan,
                 bucket: bucket,
                 sessionKind: "llama",
                 promptTokens: promptTokens,
@@ -2255,7 +2252,6 @@ public struct RealModelInferenceEngine: ~Copyable {
         )
 
         let seam = Self.resolveDecodePlanSeam(config: config, options: decodeOptions)
-        let plan = seam.plan
         let trunk = try DecodePathPolicy.resolvedTrunk(
             config: config,
             fusedHybridPreferred: seam.fusedHybridPreferred,
@@ -2287,7 +2283,6 @@ public struct RealModelInferenceEngine: ~Copyable {
             results.append(
                 try engine.dispatchLlamaTrunkDecode(LlamaDecodeRequest(
                     trunk: trunk,
-                    plan: plan,
                     bucket: bucket,
                     sessionKind: "llama testing helper",
                     promptTokens: prompt,
@@ -2788,8 +2783,11 @@ public struct RealModelInferenceEngine: ~Copyable {
         weightDir: String,
         layer: Int = 0,
         spatials: [Int] = [64, 128, 256],
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String]? = nil
     ) throws -> [GPT2AttentionCompileProbeResult] {
+        // Public declarations cannot reference internal symbols in default arguments,
+        // so the bootstrap seam is applied here instead of in the parameter default.
+        let environment = environment ?? Self.processEnvironment
         guard config.architecture == .gpt2 else {
             throw RealModelInferenceError.unsupportedArchitecture(
                 "GPT-2 attention compile probe supports GPT-2 architectures only."
@@ -6261,7 +6259,6 @@ public struct RealModelInferenceEngine: ~Copyable {
         compileTimeMs: Double,
         maxSeq: Int,
         metalAttention: MetalAttentionKernel,
-        plan: ResolvedDecodePlan,
         onStep: ((GenerationStep) -> Void)?,
         isCancelled: (() -> Bool)? = nil
     ) throws -> GenerationResult {
@@ -6273,23 +6270,6 @@ public struct RealModelInferenceEngine: ~Copyable {
             throw RealModelInferenceError.runtimeFailure(
                 "Llama hybrid decode state is unavailable: layers=\(compiledHybridLayers.count)/\(config.nLayer) surfaces=\(compiledHybridSurfaceHandles.count)/\(config.nLayer) qkNorms=\(compiledHybridLlamaQKNormWeights.count)/\(config.nLayer) head=\(compiledHybridHead.count) headSpatial=\(compiledHybridHeadSpatial)"
             )
-        }
-
-        if plan.trunk == .exactCPU {
-            return try dispatchLlamaTrunkDecode(LlamaDecodeRequest(
-                trunk: .exactCPU,
-                plan: plan,
-                bucket: maxSeq,
-                sessionKind: "llama",
-                promptTokens: promptTokens,
-                effectiveMaxTokens: effectiveMaxTokens,
-                temperature: temperature,
-                topP: topP,
-                compileTimeMs: compileTimeMs,
-                maxSeq: maxSeq,
-                onStep: onStep,
-                isCancelled: isCancelled
-            ))
         }
 
         try ForwardPass.initializeHybridDecodeCaches(

--- a/Tests/EspressoGenerateTests/EspressoGenerateTests.swift
+++ b/Tests/EspressoGenerateTests/EspressoGenerateTests.swift
@@ -1266,20 +1266,25 @@ private func makeStubDemoDefaults(root: URL) -> DemoDefaults {
     #expect(!chatForcesHybridFallbackDisable(generate))
 }
 
-@Test func test_applyCLIExperimentEnvironmentForcesChatFallbackDisable() {
-    let previous = getenv("ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK").map { String(cString: $0) }
-    defer {
-        if let previous {
-            setenv("ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK", previous, 1)
-        } else {
-            unsetenv("ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK")
-        }
-    }
-    unsetenv("ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK")
+@Test func test_cliDecodePathOptionsForceChatFallbackDisable() {
     var chat = Options()
     chat.command = .chat
-    applyCLIExperimentEnvironment(chat)
-    #expect(ProcessInfo.processInfo.environment["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK"] == "1")
+    #expect(cliDecodePathOptions(chat, environment: [:]).disableHybridFallback)
+
+    var generate = Options()
+    generate.command = .generate
+    #expect(!cliDecodePathOptions(generate, environment: [:]).disableHybridFallback)
+
+    generate.disableHybridFallback = true
+    #expect(cliDecodePathOptions(generate, environment: [:]).disableHybridFallback)
+
+    // Environment variables remain the fallback when the CLI does not own the flag.
+    #expect(
+        cliDecodePathOptions(
+            generate,
+            environment: ["ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK": "1"]
+        ).disableHybridFallback
+    )
 }
 
 @Test func test_implicitPromptIsNilForChat() {

--- a/Tests/RealModelInferenceTests/CompiledReadinessTests.swift
+++ b/Tests/RealModelInferenceTests/CompiledReadinessTests.swift
@@ -1,0 +1,130 @@
+import Testing
+import IOSurface
+import ANETypes
+@testable import Espresso
+@testable import RealModelInference
+
+private func makeTestSurface() -> IOSurfaceRef {
+    let surface = IOSurfaceCreate([
+        kIOSurfaceWidth: 1,
+        kIOSurfaceHeight: 1,
+        kIOSurfaceBytesPerElement: 4,
+    ] as CFDictionary)!
+    return surface
+}
+
+@Suite struct CompiledReadinessTests {
+    // MARK: CompiledReadiness transitions
+
+    @Test func readinessTransitionsBetweenNotCompiledAndCompiled() {
+        var readiness = CompiledReadiness<BaselineCompiledRuntime>.notCompiled
+        #expect(readiness.runtime == nil)
+
+        readiness = .compiled(BaselineCompiledRuntime(bucket: 256, inputSurface: makeTestSurface()))
+        switch readiness {
+        case .compiled(let runtime):
+            #expect(runtime.bucket == 256)
+        case .notCompiled:
+            Issue.record("readiness should be compiled after the transition")
+        }
+    }
+
+    @Test func runtimeAccessorExposesOnlyTheResidentRuntime() {
+        let notCompiled = CompiledReadiness<FusedHybridCompiledRuntime>.notCompiled
+        #expect(notCompiled.runtime == nil)
+
+        guard let runtime = FusedHybridCompiledRuntime(
+            bucket: 512,
+            layerCount: 4,
+            surfaceHandleCount: 4,
+            expectedLayerCount: 4
+        ) else {
+            Issue.record("a complete fused program set must validate")
+            return
+        }
+        let resident = CompiledReadiness<FusedHybridCompiledRuntime>.compiled(runtime)
+        #expect(resident.runtime?.bucket == 512)
+    }
+
+    // MARK: SplitHybridCompiledRuntime validation
+
+    @Test func splitHybridRuntimeRejectsIncompleteProgramSets() {
+        // Missing layers
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 3, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 1, headSpatial: 32
+        ) == nil)
+        // Missing surfaces
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 3,
+            expectedLayerCount: 4, headCount: 1, headSpatial: 32
+        ) == nil)
+        // Missing head
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 0, headSpatial: 32
+        ) == nil)
+        // Degenerate head spatial
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 1, headSpatial: 0
+        ) == nil)
+    }
+
+    @Test func splitHybridRuntimeValidatesQKNormWeightsOnlyWhenRequested() {
+        // GPT-2 flavor: no QK-norm requirement.
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 1, qKNormCount: nil, headSpatial: 32
+        ) != nil)
+        // Llama flavor: one entry per layer is required.
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 1, qKNormCount: 4, headSpatial: 32
+        ) != nil)
+        #expect(SplitHybridCompiledRuntime(
+            bucket: 256, layerCount: 4, surfaceHandleCount: 4,
+            expectedLayerCount: 4, headCount: 1, qKNormCount: 3, headSpatial: 32
+        ) == nil)
+    }
+
+    // MARK: FusedHybridCompiledRuntime validation
+
+    @Test func fusedHybridRuntimeRequiresEveryLayerAndSurface() {
+        #expect(FusedHybridCompiledRuntime(
+            bucket: 128, layerCount: 4, surfaceHandleCount: 4, expectedLayerCount: 4
+        ) != nil)
+        #expect(FusedHybridCompiledRuntime(
+            bucket: 128, layerCount: 2, surfaceHandleCount: 4, expectedLayerCount: 4
+        ) == nil)
+        #expect(FusedHybridCompiledRuntime(
+            bucket: 128, layerCount: 4, surfaceHandleCount: 0, expectedLayerCount: 4
+        ) == nil)
+    }
+
+    // MARK: GenerationOutputHeadSelection backend derivation
+
+    @Test func cpuSgemmSelectionCarriesItsExactBackend() {
+        for backend in [GenerationOutputHeadBackend.cpu, .cpuThenANE, .cpuPartitionedArgmax, .cpuFP16Tiled] {
+            let selection = GenerationOutputHeadSelection.cpuSgemm(backend)
+            #expect(selection.backend == backend)
+        }
+    }
+
+    @Test func stagedCPUSelectionIsPresenceTypedAgainstTheStagedHead() throws {
+        let classifierWeights = TensorBuffer(count: ModelConfig.dim * 8, zeroed: true)
+        let stagedHead = try CPUStagedExactGenerationOutputHead(
+            classifierWeights: classifierWeights,
+            vocabSize: 8,
+            layoutStrategy: .contiguous(shardSize: 4)
+        )
+        let selection = GenerationOutputHeadSelection.stagedCPU(stagedHead)
+        switch selection {
+        case .stagedCPU:
+            // Presence-typed: no guard-throw needed to reach the head.
+            #expect(true)
+        case .cpuSgemm, .aneClassifier, .aneRMSNormClassifier:
+            Issue.record("staged selection must stay in the stagedCPU case")
+        }
+    }
+}

--- a/Tests/RealModelInferenceTests/DecodePathPolicyTests.swift
+++ b/Tests/RealModelInferenceTests/DecodePathPolicyTests.swift
@@ -1,0 +1,244 @@
+import Testing
+import ModelSupport
+@testable import RealModelInference
+
+private func makeDecodePathPolicyConfig(
+    name: String = "llama3",
+    architecture: MultiModelConfig.Architecture = .llama,
+    preferredDecodePath: MultiModelConfig.PreferredDecodePath? = nil,
+    nLayer: Int = 4
+) -> MultiModelConfig {
+    MultiModelConfig(
+        name: name,
+        nLayer: nLayer,
+        nHead: 2,
+        nKVHead: 2,
+        dModel: 8,
+        headDim: 4,
+        hiddenDim: 16,
+        vocab: 64,
+        maxSeq: 8,
+        normEps: 1e-5,
+        architecture: architecture,
+        preferredDecodePath: preferredDecodePath
+    )
+}
+
+struct DecodePathPolicyTests {
+    @Test func optionsFromEnvironmentParsesBoundedVariables() {
+        let options = DecodePathPolicy.optionsFromEnvironment([
+            "ESPRESSO_FORCE_HYBRID_DECODE": "1",
+            "ESPRESSO_USE_CPU_EXACT_DECODE": "1",
+            "ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK": "1",
+            "DECODE_EVAL_FFN_ONLY": "1"
+        ])
+        #expect(options == DecodePathOptions(
+            forceHybridDecode: true,
+            useCPUExactDecode: true,
+            disableHybridFallback: true,
+            ffnOnlyEval: true
+        ))
+    }
+
+    @Test func optionsFromEnvironmentIgnoresUnsetAndOtherValues() {
+        #expect(DecodePathPolicy.optionsFromEnvironment([:]) == DecodePathOptions())
+        for rawValue in ["0", "", "true", "2"] {
+            let options = DecodePathPolicy.optionsFromEnvironment([
+                "ESPRESSO_FORCE_HYBRID_DECODE": rawValue,
+                "ESPRESSO_USE_CPU_EXACT_DECODE": rawValue,
+                "ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK": rawValue,
+                "DECODE_EVAL_FFN_ONLY": rawValue
+            ])
+            #expect(!options.forceHybridDecode)
+            #expect(!options.useCPUExactDecode)
+            #expect(!options.disableHybridFallback)
+            #expect(!options.ffnOnlyEval)
+        }
+    }
+
+    @Test func resolveSelectsTrunkPerExplicitOptions() {
+        let llama = makeDecodePathPolicyConfig(name: "llama3")
+        let qwenLegacy = makeDecodePathPolicyConfig(name: "Qwen3-0.6B")
+
+        var cases: [(
+            options: DecodePathOptions,
+            fusedPreferred: Bool,
+            expected: Trunk,
+            config: MultiModelConfig
+        )] = [
+            // Plain llama: split hybrid by default.
+            (DecodePathOptions(), false, .splitHybrid, llama),
+            // Fused preference promotes the trunk.
+            (DecodePathOptions(), true, .fusedHybrid, llama),
+            // CPU-exact beats fused preference.
+            (DecodePathOptions(useCPUExactDecode: true), true, .exactCPU, llama),
+            // Force-hybrid rescues legacy Qwen off the exact-CPU oracle.
+            (DecodePathOptions(forceHybridDecode: true), false, .splitHybrid, qwenLegacy),
+            // Legacy Qwen routing lands on exact-CPU without overrides.
+            (DecodePathOptions(), false, .exactCPU, qwenLegacy),
+            // Declared artifact path wins over the name heuristic.
+            (
+                DecodePathOptions(),
+                false,
+                .splitHybrid,
+                makeDecodePathPolicyConfig(name: "Qwen2.5-0.5B-Instruct", preferredDecodePath: .hybrid)
+            ),
+            (
+                DecodePathOptions(),
+                true,
+                .fusedHybrid,
+                makeDecodePathPolicyConfig(name: "llama-fused", preferredDecodePath: .hybrid)
+            )
+        ]
+
+        for testCase in cases {
+            let plan = DecodePathPolicy.resolve(
+                config: testCase.config,
+                fusedHybridPreferred: testCase.fusedPreferred,
+                options: testCase.options
+            )
+            #expect(plan.trunk == testCase.expected)
+        }
+    }
+
+    @Test func forceHybridBeatsCPUExactOption() {
+        let plan = DecodePathPolicy.resolve(
+            config: makeDecodePathPolicyConfig(),
+            fusedHybridPreferred: true,
+            options: DecodePathOptions(forceHybridDecode: true, useCPUExactDecode: true)
+        )
+        #expect(plan.trunk == .fusedHybrid)
+    }
+
+    @Test func resolveCarriesFallbackPolicyAndDispatchOption() {
+        let config = makeDecodePathPolicyConfig()
+        let rerunPlan = DecodePathPolicy.resolve(
+            config: config,
+            fusedHybridPreferred: false,
+            options: DecodePathOptions(ffnOnlyEval: true)
+        )
+        #expect(rerunPlan.fallbackPolicy == .rerunOnBaseline)
+        #expect(rerunPlan.allowsHybridFallback)
+        #expect(rerunPlan.ffnOnlyEval)
+
+        let disabledPlan = DecodePathPolicy.resolve(
+            config: config,
+            fusedHybridPreferred: false,
+            options: DecodePathOptions(disableHybridFallback: true)
+        )
+        #expect(disabledPlan.fallbackPolicy == .disabled)
+        #expect(!disabledPlan.allowsHybridFallback)
+        #expect(!disabledPlan.ffnOnlyEval)
+    }
+
+    @Test func cpuExactRoutingSourceIsClassified() {
+        let operatorPlan = DecodePathPolicy.resolve(
+            config: makeDecodePathPolicyConfig(name: "llama3"),
+            fusedHybridPreferred: false,
+            options: DecodePathOptions(useCPUExactDecode: true)
+        )
+        #expect(operatorPlan.cpuExactRoutingSource == .operatorRequest)
+
+        let artifactPlan = DecodePathPolicy.resolve(
+            config: makeDecodePathPolicyConfig(preferredDecodePath: .exactCPU),
+            fusedHybridPreferred: false,
+            options: DecodePathOptions()
+        )
+        #expect(artifactPlan.cpuExactRoutingSource == .artifactDeclaration)
+
+        let legacyPlan = DecodePathPolicy.resolve(
+            config: makeDecodePathPolicyConfig(name: "Qwen3-0.6B"),
+            fusedHybridPreferred: false,
+            options: DecodePathOptions()
+        )
+        #expect(legacyPlan.cpuExactRoutingSource == .legacyQwenNameRouting)
+
+        let hybridPlan = DecodePathPolicy.resolve(
+            config: makeDecodePathPolicyConfig(name: "Qwen3-0.6B"),
+            fusedHybridPreferred: false,
+            options: DecodePathOptions(forceHybridDecode: true)
+        )
+        #expect(hybridPlan.cpuExactRoutingSource == nil)
+    }
+
+    @Test func explicitOptionsWinOverEnvironmentSeededDefaults() {
+        // Edge case §9.1: env set AND explicit option passed → explicit wins;
+        // env remains the fallback when no option is passed.
+        let env = ["ESPRESSO_FORCE_HYBRID_DECODE": "1"]
+        let seeded = DecodePathPolicy.optionsFromEnvironment(env)
+        #expect(seeded.forceHybridDecode)
+
+        let qwenLegacy = makeDecodePathPolicyConfig(name: "Qwen3-0.6B")
+        #expect(
+            DecodePathPolicy.resolve(config: qwenLegacy, fusedHybridPreferred: false, options: seeded).trunk != .exactCPU
+        )
+
+        let explicitOff = DecodePathOptions()
+        #expect(
+            DecodePathPolicy.resolve(config: qwenLegacy, fusedHybridPreferred: false, options: explicitOff).trunk == .exactCPU
+        )
+    }
+
+    @Test func resolvedTrunkThrowsWhenFallbackDisabledOnExactCPU() throws {
+        let qwenLegacy = makeDecodePathPolicyConfig(name: "Qwen3-0.6B")
+        do {
+            _ = try DecodePathPolicy.resolvedTrunk(
+                config: qwenLegacy,
+                fusedHybridPreferred: false,
+                options: DecodePathOptions(disableHybridFallback: true)
+            )
+            Issue.record("Expected hybridFallbackDisabled")
+        } catch let error as RealModelInferenceError {
+            guard case let .hybridFallbackDisabled(stage, reason) = error else {
+                Issue.record("Unexpected error shape: \(error)")
+                return
+            }
+            #expect(stage == "llama trunk selection")
+            #expect(reason.contains("legacy Qwen CPU-exact routing policy"))
+            #expect(error.errorDescription?.contains("ESPRESSO_REALMODEL_DISABLE_HYBRID_FALLBACK=1") == true)
+        }
+    }
+
+    @Test func resolvedTrunkReasonNamesCPUExactOption() throws {
+        do {
+            _ = try DecodePathPolicy.resolvedTrunk(
+                config: makeDecodePathPolicyConfig(name: "llama3"),
+                fusedHybridPreferred: false,
+                options: DecodePathOptions(useCPUExactDecode: true, disableHybridFallback: true)
+            )
+            Issue.record("Expected hybridFallbackDisabled")
+        } catch let error as RealModelInferenceError {
+            guard case let .hybridFallbackDisabled(_, reason) = error else {
+                Issue.record("Unexpected error shape: \(error)")
+                return
+            }
+            #expect(reason.contains("ESPRESSO_USE_CPU_EXACT_DECODE"))
+        }
+    }
+
+    @Test func resolvedTrunkReasonNamesDeclaredArtifactPath() throws {
+        do {
+            _ = try DecodePathPolicy.resolvedTrunk(
+                config: makeDecodePathPolicyConfig(preferredDecodePath: .exactCPU),
+                fusedHybridPreferred: false,
+                options: DecodePathOptions(disableHybridFallback: true)
+            )
+            Issue.record("Expected hybridFallbackDisabled")
+        } catch let error as RealModelInferenceError {
+            guard case let .hybridFallbackDisabled(_, reason) = error else {
+                Issue.record("Unexpected error shape: \(error)")
+                return
+            }
+            #expect(reason.contains("preferredDecodePath=exact_cpu in metadata.json"))
+        }
+    }
+
+    @Test func resolvedTrunkKeepsHybridWhenFallbackDisabled() throws {
+        let trunk = try DecodePathPolicy.resolvedTrunk(
+            config: makeDecodePathPolicyConfig(name: "llama3"),
+            fusedHybridPreferred: true,
+            options: DecodePathOptions(disableHybridFallback: true)
+        )
+        #expect(trunk.isHybrid)
+    }
+}

--- a/Tests/RealModelInferenceTests/EmissionCoreTests.swift
+++ b/Tests/RealModelInferenceTests/EmissionCoreTests.swift
@@ -1,0 +1,208 @@
+import Testing
+import ANETypes
+@testable import RealModelInference
+
+private func makeEmission(
+    promptTokens: [TokenID] = [10, 11],
+    capacity: Int = 8,
+    eos: EOSPolicy,
+    onStep: ((GenerationStep) -> Void)? = nil,
+    startNanos: UInt64 = 1_000_000_000
+) -> EmissionCore {
+    EmissionCore(
+        promptTokens: promptTokens,
+        capacity: capacity,
+        eos: eos,
+        onStep: onStep,
+        decodeText: { $0.map(String.init).joined(separator: ",") },
+        startNanos: startNanos
+    )
+}
+
+@Suite struct EmissionCoreTests {
+    // MARK: EOSPolicy injection
+
+    @Test func fixedPolicyTerminatesOnTheInjectedConstantOnly() {
+        let emission = makeEmission(eos: .fixed(50_256))
+        #expect(emission.eosTokenID == 50_256)
+        #expect(emission.terminatesDecoding(50_256))
+        #expect(!emission.terminatesDecoding(50_255))
+        #expect(!emission.terminatesDecoding(0))
+    }
+
+    @Test func fromConfigPolicyUsesTheArtifactValueAndNilDisablesEOS() {
+        let qwenLike = makeEmission(eos: .fromConfig(151_643))
+        #expect(qwenLike.terminatesDecoding(151_643))
+        #expect(!qwenLike.terminatesDecoding(151_644))
+
+        let noEOS = makeEmission(eos: .fromConfig(nil))
+        #expect(noEOS.eosTokenID == nil)
+        #expect(!noEOS.terminatesDecoding(0))
+    }
+
+    // MARK: Concern 1 — first-token latency capture
+
+    @Test func firstTokenLatencyIsZeroUntilCapturedThenIdempotent() {
+        var emission = makeEmission(eos: .fixed(50_256))
+        #expect(emission.firstTokenLatencyMs == 0)
+
+        emission.recordFirstTokenIfFirst(at: 1_002_500_000)
+        #expect(emission.firstTokenLatencyMs == 2.5)
+
+        emission.recordFirstTokenIfFirst(at: 1_900_000_000)
+        #expect(emission.firstTokenLatencyMs == 2.5)
+    }
+
+    @Test func emitCapturesFirstTokenLatencyWithoutExplicitRecord() {
+        var emission = makeEmission(eos: .fixed(50_256))
+        emission.emit(7, at: 1_004_000_000)
+        #expect(emission.firstTokenLatencyMs == 4)
+    }
+
+    // MARK: Concerns 1–3 — emit bookkeeping and step construction
+
+    @Test func emitAppendsTokensRecordsLatenciesAndFiresSteps() throws {
+        var steps: [GenerationStep] = []
+        var emission = makeEmission(eos: .fixed(50_256)) { steps.append($0) }
+
+        emission.emit(7, at: 1_001_000_000)
+        emission.emit(9, at: 1_003_500_000)
+
+        #expect(emission.generatedTokens == [7, 9])
+        #expect(emission.generatedTokenCount == 2)
+        #expect(emission.allTokens == [10, 11, 7, 9])
+        #expect(emission.allTokensCount == 4)
+        #expect(emission.tokenLatenciesMs.count == 2)
+
+        #expect(steps.count == 2)
+        let first = try #require(steps.first)
+        #expect(first.token == 7)
+        #expect(first.generatedTokens == [7])
+        #expect(first.text == "10,11,7")
+        #expect(first.tokenLatencyMs == 1)
+        #expect(first.elapsedMs == 1)
+        #expect(first.firstTokenLatencyMs == 1)
+
+        let second = try #require(steps.last)
+        #expect(second.token == 9)
+        #expect(second.generatedTokens == [7, 9])
+        #expect(second.text == "10,11,7,9")
+        #expect(second.tokenLatencyMs == 2.5)
+        #expect(second.elapsedMs == 3.5)
+        #expect(second.firstTokenLatencyMs == 1)
+        let secondTPS = EmissionCore.tokensPerSecond(count: 2, elapsedMs: 3.5)
+        #expect(abs(second.tokensPerSecond - secondTPS) < 1e-9)
+    }
+
+    @Test func terminalTokenLandsInTokensButNotTextAndFiresNoStep() {
+        var steps: [GenerationStep] = []
+        var emission = makeEmission(promptTokens: [10], eos: .fromConfig(99)) { steps.append($0) }
+
+        emission.recordTerminalToken(99)
+
+        #expect(emission.generatedTokens == [99])
+        #expect(emission.allTokens == [10])
+        #expect(steps.isEmpty)
+
+        let result = emission.makeResult(
+            compileTimeMs: 0,
+            trunk: .exactCPU,
+            at: 1_010_000_000
+        )
+        #expect(result.tokens == [99])
+        #expect(result.text == "10")
+        #expect(result.tokensPerSecond == 100)
+    }
+
+    // MARK: Concern 2 — one rate formula
+
+    @Test func tokensPerSecondFormulaIsSharedByLoopAndAssemblyPaths() {
+        #expect(EmissionCore.tokensPerSecond(count: 0, elapsedMs: 12.5) == 0)
+        let rate = EmissionCore.tokensPerSecond(count: 25, elapsedMs: 1_250)
+        #expect(abs(rate - 20) < 1e-9)
+
+        var emission = makeEmission(eos: .fixed(50_256))
+        emission.emit(1, at: 1_001_250_000)
+        let result = emission.makeResult(compileTimeMs: 0, at: 1_001_250_000)
+        #expect(abs(result.tokensPerSecond - EmissionCore.tokensPerSecond(count: 1, elapsedMs: 1.25)) < 1e-9)
+    }
+
+    // MARK: Concern 4 — result assembly
+
+    @Test func makeResultDefaultsRepresentTypeLevelAbsence() {
+        let emission = makeEmission(eos: .fixed(50_256))
+        let result = emission.makeResult(
+            compileTimeMs: 3.25,
+            at: 1_000_500_000
+        )
+        #expect(result.text == "10,11")
+        #expect(result.tokens.isEmpty)
+        #expect(result.promptTokens == [10, 11])
+        #expect(result.tokensPerSecond == 0)
+        #expect(result.compileTimeMs == 3.25)
+        #expect(result.firstTokenLatencyMs == 0)
+        #expect(result.trunk == nil)
+        #expect(result.decodePath == "unknown")
+        #expect(result.exactHeadBackend == "unknown")
+        #expect(!result.cachedBindingsEnabled)
+        #expect(result.hopsPerToken == nil)
+        #expect(result.decodeProfileReport == nil)
+    }
+
+    @Test func makeResultPopulatesTrunkFieldsWhenTheLoopSuppliesThem() {
+        var emission = makeEmission(eos: .fromConfig(nil))
+        emission.emit(5, at: 1_001_000_000)
+
+        let fused = emission.makeResult(
+            compileTimeMs: 0,
+            trunk: .fusedHybrid,
+            hopsPerToken: 6
+        )
+        #expect(fused.trunk == .fusedHybrid)
+        #expect(fused.hopsPerToken == 6)
+        #expect(fused.tokens == [5])
+
+        let split = emission.makeResult(compileTimeMs: 0, trunk: .splitHybrid)
+        #expect(split.trunk == .splitHybrid)
+        #expect(split.exactHeadBackend == "unknown")
+    }
+
+    @Test func makeResultOverridesServeDistinctEarlyReturnShapes() {
+        var emission = makeEmission(promptTokens: [10], eos: .fromConfig(99))
+        emission.recordTerminalToken(99)
+
+        let earlyReturn = emission.makeResult(
+            compileTimeMs: 1,
+            exactHeadBackend: "cpu_exact_two_token_draft",
+            trunk: .exactCPU,
+            tokensPerSecondOverride: 0,
+            textOverride: "10,99"
+        )
+        #expect(earlyReturn.tokens == [99])
+        #expect(earlyReturn.tokensPerSecond == 0)
+        #expect(earlyReturn.firstTokenLatencyMs == 0)
+        #expect(earlyReturn.text == "10,99")
+        #expect(earlyReturn.trunk == .exactCPU)
+
+        var running = makeEmission(eos: .fromConfig(nil))
+        running.emit(5, at: 1_002_000_000)
+        let budgetExhausted = running.makeResult(
+            compileTimeMs: 1,
+            exactHeadBackend: "cpu_exact_two_token_draft",
+            trunk: .exactCPU
+        )
+        #expect(budgetExhausted.committedExactTokensPerPass == nil)
+        #expect(budgetExhausted.acceptedFutureTokensPerPass == nil)
+        #expect(budgetExhausted.tokens == [5])
+
+        let finalPass = running.makeResult(
+            compileTimeMs: 1,
+            exactHeadBackend: "cpu_exact_two_token_draft",
+            committedExactTokensPerPass: 1.75,
+            acceptedFutureTokensPerPass: 0.5,
+            trunk: .exactCPU
+        )
+        #expect(finalPass.committedExactTokensPerPass == 1.75)
+        #expect(finalPass.acceptedFutureTokensPerPass == 0.5)
+    }
+}


### PR DESCRIPTION
## Summary

Lands the reviewed decode-path stack (T1 DecodePathPolicy #30 → T2 EmissionCore #34 → T3 CompiledReadiness #36) on top of the merged engine-policies stack (#31→#32→#35→#37), resolving the 22 textual conflicts between the two chains in `RealModelInferenceEngine.swift`.

## Conflict resolution rules

- **Policy access wins**: all env reads use `policies.environment` / `EnginePolicies` fields (#35's resolve-once discipline); no direct `Self.processEnvironment` reads remain on serving paths.
- **Structure from T1/T3 kept**: `resolveDecodePlanSeam` + single Trunk dispatch via `prepareLlamaTrunkDecode`, unified split-hybrid ensure twin, deleted GPT-2-only duplicate body, dropped redundant exact-CPU early dispatch inside hybrid loop.
- **Deletions honored**: `loadTestingTopLevelAssets` stays deleted (#31 unified loaders).
- Fallback gates use `!plan.allowsHybridFallback` derived from `policies.environment`.

## Verification

- `swift build` green after each of T1/T2/T3 integration commits
- Full suite: all tests pass, 0 failures (default gates)
- ANE_HARDWARE_TESTS=1 full run: only 2 pre-existing bundle-missing parity failures, identical on pre-merge baseline d66443b; one flaky compile-budget artifact did not reproduce
- Supersedes #30, #34, #36